### PR TITLE
Add an initial set of Ultimaker materials

### DIFF
--- a/ultimaker_abs_black.xml.fdm_material
+++ b/ultimaker_abs_black.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Black</color>
+        </name>
+        <GUID>2f9d2279-9b0e-4765-bf9b-d1e1e13f3c49</GUID>
+        <version>0</version>
+        <color_code>#2a292a</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_blue.xml.fdm_material
+++ b/ultimaker_abs_blue.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Blue</color>
+        </name>
+        <GUID>7c9575a6-c8d6-40ec-b3dd-18d7956bfaae</GUID>
+        <version>0</version>
+        <color_code>#00387b</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_green.xml.fdm_material
+++ b/ultimaker_abs_green.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Green</color>
+        </name>
+        <GUID>3400c0d1-a4e3-47de-a444-7b704f287171</GUID>
+        <version>0</version>
+        <color_code>#61993b</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_grey.xml.fdm_material
+++ b/ultimaker_abs_grey.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Grey</color>
+        </name>
+        <GUID>8b75b775-d3f2-4d0f-8fb2-2a3dd53cf673</GUID>
+        <version>0</version>
+        <color_code>#52595d</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_orange.xml.fdm_material
+++ b/ultimaker_abs_orange.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Orange</color>
+        </name>
+        <GUID>0b4ca6ef-eac8-4b23-b3ca-5f21af00e54f</GUID>
+        <version>0</version>
+        <color_code>#ed6b21</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_pearl-gold.xml.fdm_material
+++ b/ultimaker_abs_pearl-gold.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Pearl Gold</color>
+        </name>
+        <GUID>7cbdb9ca-081a-456f-a6ba-f73e4e9cb856</GUID>
+        <version>0</version>
+        <color_code>#80643f</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_red.xml.fdm_material
+++ b/ultimaker_abs_red.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Red</color>
+        </name>
+        <GUID>5df7afa6-48bd-4c19-b314-839fe9f08f1f</GUID>
+        <version>0</version>
+        <color_code>#bb1e10</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_silver-metallic.xml.fdm_material
+++ b/ultimaker_abs_silver-metallic.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Silver Metallic</color>
+        </name>
+        <GUID>763c926e-a5f7-4ba0-927d-b4e038ea2735</GUID>
+        <version>0</version>
+        <color_code>#a1a1a0</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_white.xml.fdm_material
+++ b/ultimaker_abs_white.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>White</color>
+        </name>
+        <GUID>5253a75a-27dc-4043-910f-753ae11bc417</GUID>
+        <version>0</version>
+        <color_code>#ecece7</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_abs_yellow.xml.fdm_material
+++ b/ultimaker_abs_yellow.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated ABS profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Yellow</color>
+        </name>
+        <GUID>e873341d-d9b8-45f9-9a6f-5609e1bcff68</GUID>
+        <version>0</version>
+        <color_code>#f7b500</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_black.xml.fdm_material
+++ b/ultimaker_cpe_black.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Black</color>
+        </name>
+        <GUID>a8955dc3-9d7e-404d-8c03-0fd6fee7f22d</GUID>
+        <version>0</version>
+        <color_code>#2a292a</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_blue.xml.fdm_material
+++ b/ultimaker_cpe_blue.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Blue</color>
+        </name>
+        <GUID>4d816290-ce2e-40e0-8dc8-3f702243131e</GUID>
+        <version>0</version>
+        <color_code>#00a3e0</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_dark-grey.xml.fdm_material
+++ b/ultimaker_cpe_dark-grey.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Dark Grey</color>
+        </name>
+        <GUID>10961c00-3caf-48e9-a598-fa805ada1e8d</GUID>
+        <version>0</version>
+        <color_code>#4f5250</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_green.xml.fdm_material
+++ b/ultimaker_cpe_green.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Green</color>
+        </name>
+        <GUID>7ff6d2c8-d626-48cd-8012-7725fa537cc9</GUID>
+        <version>0</version>
+        <color_code>#78be20</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_light-grey.xml.fdm_material
+++ b/ultimaker_cpe_light-grey.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Light Grey</color>
+        </name>
+        <GUID>173a7bae-5e14-470e-817e-08609c61e12b</GUID>
+        <version>0</version>
+        <color_code>#c5c7c4</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_red.xml.fdm_material
+++ b/ultimaker_cpe_red.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Red</color>
+        </name>
+        <GUID>00181d6c-7024-479a-8eb7-8a2e38a2619a</GUID>
+        <version>0</version>
+        <color_code>#c8102e</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_transparent.xml.fdm_material
+++ b/ultimaker_cpe_transparent.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Transparent</color>
+        </name>
+        <GUID>bd0d9eb3-a920-4632-84e8-dcd6086746c5</GUID>
+        <version>0</version>
+        <color_code>#d0d0d0</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_white.xml.fdm_material
+++ b/ultimaker_cpe_white.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>White</color>
+        </name>
+        <GUID>881c888e-24fb-4a64-a4ac-d5c95b096cd7</GUID>
+        <version>0</version>
+        <color_code>#f1ece1</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_yellow.xml.fdm_material
+++ b/ultimaker_cpe_yellow.xml.fdm_material
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated CPE profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Yellow</color>
+        </name>
+        <GUID>b9176a2a-7a0f-4821-9f29-76d882a88682</GUID>
+        <version>0</version>
+        <color_code>#f6b600</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_black.xml.fdm_material
+++ b/ultimaker_pla_black.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Black</color>
+        </name>
+        <GUID>3ee70a86-77d8-4b87-8005-e4a1bc57d2ce</GUID>
+        <version>0</version>
+        <color_code>#0e0e10</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_blue.xml.fdm_material
+++ b/ultimaker_pla_blue.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Blue</color>
+        </name>
+        <GUID>44a029e6-e31b-4c9e-a12f-9282e29a92ff</GUID>
+        <version>0</version>
+        <color_code>#00387b</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_green.xml.fdm_material
+++ b/ultimaker_pla_green.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Green</color>
+        </name>
+        <GUID>2433b8fb-dcd6-4e36-9cd5-9f4ee551c04c</GUID>
+        <version>0</version>
+        <color_code>#61993b</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_magenta.xml.fdm_material
+++ b/ultimaker_pla_magenta.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Magenta</color>
+        </name>
+        <GUID>fe3982c8-58f4-4d86-9ac0-9ff7a3ab9cbc</GUID>
+        <version>0</version>
+        <color_code>#bc4077</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_orange.xml.fdm_material
+++ b/ultimaker_pla_orange.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Orange</color>
+        </name>
+        <GUID>d9549dba-b9df-45b9-80a5-f7140a9a2f34</GUID>
+        <version>0</version>
+        <color_code>#ed6b21</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_pearl-white.xml.fdm_material
+++ b/ultimaker_pla_pearl-white.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Pearl-White</color>
+        </name>
+        <GUID>d9fc79db-82c3-41b5-8c99-33b3747b8fb3</GUID>
+        <version>0</version>
+        <color_code>#e3d9c6</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_red.xml.fdm_material
+++ b/ultimaker_pla_red.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Red</color>
+        </name>
+        <GUID>9cfe5bf1-bdc5-4beb-871a-52c70777842d</GUID>
+        <version>0</version>
+        <color_code>#bb1e10</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_silver-metallic.xml.fdm_material
+++ b/ultimaker_pla_silver-metallic.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Silver Metallic</color>
+        </name>
+        <GUID>0e01be8c-e425-4fb1-b4a3-b79f255f1db9</GUID>
+        <version>0</version>
+        <color_code>#a1a1a0</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_transparent.xml.fdm_material
+++ b/ultimaker_pla_transparent.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Transparent</color>
+        </name>
+        <GUID>532e8b3d-5fd4-4149-b936-53ada9bd6b85</GUID>
+        <version>0</version>
+        <color_code>#d0d0d0</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_white.xml.fdm_material
+++ b/ultimaker_pla_white.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>White</color>
+        </name>
+        <GUID>e509f649-9fe6-4b14-ac45-d441438cb4ef</GUID>
+        <version>0</version>
+        <color_code>#f1ece1</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla_yellow.xml.fdm_material
+++ b/ultimaker_pla_yellow.xml.fdm_material
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Automatically generated PLA profile. Data in this file may not be not correct.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Yellow</color>
+        </name>
+        <GUID>9c1959d0-f597-46ec-9131-34020c7a54fc</GUID>
+        <version>0</version>
+        <color_code>#f9a800</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker" product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
These materials are auto-generated by a script, based on the generic profiles, and may contain incorrect data.