### PR TITLE
Import Dagoma material specifications

### DIFF
--- a/chromatik_pla.xml.fdm_material
+++ b/chromatik_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Chromatik</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.74</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">205</setting>
+    </settings>
+</fdmmaterial>

--- a/fiberlogy_hd_pla.xml.fdm_material
+++ b/fiberlogy_hd_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Fiberlogy HD</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.74</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+    </settings>
+</fdmmaterial>

--- a/filo3d_pla.xml.fdm_material
+++ b/filo3d_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Filo3D</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">205</setting>
+    </settings>
+</fdmmaterial>

--- a/filo3d_pla_green.xml.fdm_material
+++ b/filo3d_pla_green.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Filo3D</brand>
+            <material>PLA</material>
+            <color>Green</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+    </settings>
+</fdmmaterial>

--- a/filo3d_pla_red.xml.fdm_material
+++ b/filo3d_pla_red.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Filo3D</brand>
+            <material>PLA</material>
+            <color>Red</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">220</setting>
+    </settings>
+</fdmmaterial>

--- a/octofiber_pla.xml.fdm_material
+++ b/octofiber_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>OctoFiber</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.74</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+    </settings>
+</fdmmaterial>

--- a/polyflex_pla.xml.fdm_material
+++ b/polyflex_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>PolyFlex</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">230</setting>
+    </settings>
+</fdmmaterial>

--- a/polymax_pla.xml.fdm_material
+++ b/polymax_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>PolyMax</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+    </settings>
+</fdmmaterial>

--- a/polyplus_pla.xml.fdm_material
+++ b/polyplus_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>PolyPlus</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+    </settings>
+</fdmmaterial>

--- a/polywood_pla.xml.fdm_material
+++ b/polywood_pla.xml.fdm_material
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>PolyWood</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
This is extracted (automatically, with a script) from the
resources/XML/xml_config.xml file installed by the Windows install
CuraByDagoma_E200_1480427910_d0965d25707767ef87c626dfbaaab4c9.zip
(dist.dagoma.fr).

Dagoma is the main distributor of these material brands.

Note: the filament_flow setting is *NOT* imported as there is no such
thing in the current Cura version in materials

Note: the color_code are not set

Note: the Cura UI is not intuitive with "Generic" types, you get menus
such as "brand → PLA → PLA", which is redundant.

Note: XML for materials, JSON for printers and INI for qualities looks
inconsistent

Note: actual printing untested