### PR TITLE
Add jellybox 3d printer support

### DIFF
--- a/generic_petg.xml.fdm_material
+++ b/generic_petg.xml.fdm_material
@@ -23,7 +23,7 @@ Generic PETG profile. The data in this file may not be correct for your specific
         <setting key="print temperature">215</setting>
         <setting key="heated bed temperature">70</setting>
         <setting key="standby temperature">120</setting>
-        
+
         <machine>
            <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
            <setting key="print temperature">220</setting>
@@ -35,6 +35,15 @@ Generic PETG profile. The data in this file may not be correct for your specific
            <hotend id="0.25 mm" />
            <hotend id="0.4 mm" />
            <hotend id="0.8 mm" />
+       </machine>
+       <machine>
+         <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+         <setting key="print temperature">235</setting>
+         <setting key="heated bed temperature">55</setting>
+
+         <hotend id="0.4 mm" />
+         <hotend id="0.4 mm 2-fans" />
        </machine>
     </settings>
 </fdmmaterial>

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -64,7 +64,7 @@ Generic PLA profile. The data in this file may not be correct for your specific 
                 <setting key="hardware compatible">yes</setting>
             </hotend>
         </machine>
-        
+
         <machine>
            <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
            <setting key="print temperature">185</setting>
@@ -74,6 +74,16 @@ Generic PLA profile. The data in this file may not be correct for your specific 
            <hotend id="0.25 mm" />
            <hotend id="0.4 mm" />
            <hotend id="0.8 mm" />
+       </machine>
+
+       <machine>
+         <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+         <setting key="print temperature">210</setting>
+         <setting key="heated bed temperature">55</setting>
+
+         <hotend id="0.4 mm" />
+         <hotend id="0.4 mm 2-fans" />
        </machine>
     </settings>
 </fdmmaterial>

--- a/imade3d_petg_green.xml.fdm_material
+++ b/imade3d_petg_green.xml.fdm_material
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PLA profile. Serves as an starting point for IMADE3D JellyBOX;
+PLA from various manufacturers may require different settings.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>IMADE3D</brand>
+            <material>PETG</material>
+            <color>Green</color>
+        </name>
+        <GUID>e4c2e2bb-ef6c-46e7-ad41-6420d23943eb</GUID>
+        <version>1</version>
+        <color_code>#a5da00</color_code>
+    </metadata>
+    <properties>
+        <density>1.38</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">235</setting>
+        <setting key="heated bed temperature">50</setting>
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/imade3d_petg_pink.xml.fdm_material
+++ b/imade3d_petg_pink.xml.fdm_material
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PLA profile. Serves as an starting point for IMADE3D JellyBOX;
+PLA from various manufacturers may require different settings.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>IMADE3D</brand>
+            <material>PETG</material>
+            <color>Pink</color>
+        </name>
+        <GUID>ba534364-680d-49ed-b2a3-46c502093135</GUID>
+        <version>1</version>
+        <color_code>#eb006a</color_code>
+    </metadata>
+    <properties>
+        <density>1.38</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">235</setting>
+        <setting key="heated bed temperature">50</setting>
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/imade3d_pla_green.xml.fdm_material
+++ b/imade3d_pla_green.xml.fdm_material
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PLA profile. Serves as an starting point for IMADE3D JellyBOX;
+PLA from various manufacturers may require different settings.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>IMADE3D</brand>
+            <material>PLA</material>
+            <color>Green</color>
+        </name>
+        <GUID>d5572db9-0f37-47c0-aac5-84541b9ee8c2</GUID>
+        <version>1</version>
+        <color_code>#a5da00</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+        <setting key="heated bed temperature">50</setting>
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/imade3d_pla_pink.xml.fdm_material
+++ b/imade3d_pla_pink.xml.fdm_material
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PLA profile. Serves as an starting point for IMADE3D JellyBOX;
+PLA from various manufacturers may require different settings.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>IMADE3D</brand>
+            <material>PLA</material>
+            <color>Pink</color>
+        </name>
+        <GUID>2ea65303-590f-40e6-8851-348219836860</GUID>
+        <version>1</version>
+        <color_code>#eb006a</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">210</setting>
+        <setting key="heated bed temperature">50</setting>
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -5,9 +5,9 @@ Generic PC profile. The data in this file may not be correct for your specific m
 <fdmmaterial xmlns="http://www.ultimaker.com/material">
     <metadata>
         <name>
-            <brand>Generic</brand>
+            <brand>Ultimaker</brand>
             <material>PC</material>
-            <color>Generic</color>
+            <color>White</color>
         </name>
         <GUID>5e786b05-a620-4a87-92d0-f02becc1ff98</GUID>
         <version>1</version>


### PR DESCRIPTION
fully tested support for jellybox 3d printer. currently only adds PLA and basic PETG support. 