### PR TITLE
Tweak generic petg

### DIFF
--- a/generic_petg.xml.fdm_material
+++ b/generic_petg.xml.fdm_material
@@ -16,14 +16,14 @@ Generic PETG profile. The data in this file may not be correct for your specific
         <adhesion_info>Set your prime speed to a low value (8mm/sec)</adhesion_info>
     </metadata>
     <properties>
-        <density>1.24</density>
+        <density>1.38</density>
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="print temperature">215</setting>
+        <setting key="print temperature">235</setting>
         <setting key="heated bed temperature">70</setting>
         <setting key="standby temperature">120</setting>
-        
+
         <machine>
            <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
            <setting key="print temperature">220</setting>

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -5,9 +5,9 @@ Generic PC profile. The data in this file may not be correct for your specific m
 <fdmmaterial xmlns="http://www.ultimaker.com/material">
     <metadata>
         <name>
-            <brand>Generic</brand>
+            <brand>Ultimaker</brand>
             <material>PC</material>
-            <color>Generic</color>
+            <color>White</color>
         </name>
         <GUID>5e786b05-a620-4a87-92d0-f02becc1ff98</GUID>
         <version>1</version>


### PR DESCRIPTION
- change density from 1.24 (common middle ground for PLA) to 1.38
(common middle ground for PETG)
- change print temperature form 215C to 235C, which I’d say is a more
realistic base temperature for PETG
- of course these are generic, and will be overiden by specific
machines, but these defaults can still confuse some or cause havoc
since they are a fallback