### PR TITLE
Add generic 1.75mm materials

### DIFF
--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic ABS 1.75mm profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>ABS</material>
+            <color>Generic</color>
+        </name>
+        <GUID>2780b345-577b-4a24-a2c5-12e6aad3e690</GUID>
+        <version>1</version>
+        <color_code>#8cb219</color_code>
+    </metadata>
+    <properties>
+        <density>1.10</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">230</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">200</setting>
+    </settings>
+</fdmmaterial>

--- a/generic_cpe_175.xml.fdm_material
+++ b/generic_cpe_175.xml.fdm_material
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic CPE 1.75mm profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>CPE</material>
+            <color>Generic</color>
+        </name>
+        <GUID>da1872c1-b991-4795-80ad-bdac0f131726</GUID>
+        <version>1</version>
+        <color_code>#159499</color_code>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">240</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">175</setting>
+    </settings>
+</fdmmaterial>

--- a/generic_hips_175.xml.fdm_material
+++ b/generic_hips_175.xml.fdm_material
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic HIPS 1.75mm profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>HIPS</material>
+            <color>Generic</color>
+        </name>
+        <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
+        <version>1</version>
+        <color_code>#12f3e0</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">215</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">160</setting>
+    </settings>
+</fdmmaterial>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic Nylon 1.75mm profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>Nylon</material>
+            <color>Generic</color>
+        </name>
+        <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
+        <version>1</version>
+        <color_code>#3DF266</color_code>
+    </metadata>
+    <properties>
+        <density>1.14</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">245</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+        <setting key="retraction amount">8</setting>
+        <setting key="retraction speed">25</setting>
+    </settings>
+</fdmmaterial>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PETG 1.75mm profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>PETG</material>
+            <color>Generic</color>
+        </name>
+        <GUID>69386c85-5b6c-421a-bec5-aeb1fb33f060</GUID>
+        <version>1</version>
+        <color_code>#f3a112</color_code>
+        <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>
+        <adhesion_info>Set your prime speed to a low value (8mm/sec)</adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.38</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">215</setting>
+        <setting key="heated bed temperature">70</setting>
+        <setting key="standby temperature">120</setting>
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <setting key="print temperature">235</setting>
+            <setting key="heated bed temperature">55</setting>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PLA 1.75mm profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+        <GUID>0ff92885-617b-4144-a03c-9989872454bc</GUID>
+        <version>1</version>
+        <color_code>#ffc924</color_code>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <setting key="print temperature">210</setting>
+            <setting key="heated bed temperature">55</setting>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+        </machine>
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
This PR adds copies of the normal 2.85mm materials with a new GUID for 1.75mm materials. 

I have removed the special settings for Ultimaker and Cartesio printers (which don't apply because these use 2.85mm material), but left in the settings for the Jellybox.

See https://github.com/Ultimaker/Cura/pull/1685