### PR TITLE
Fix some issues with 1.75mm materials

### DIFF
--- a/chromatik_pla.xml.fdm_material
+++ b/chromatik_pla.xml.fdm_material
@@ -8,6 +8,7 @@
         </name>
         <GUID>69fd1f24-f411-470e-8158-9e5552f36147</GUID>
         <version>1</version>
+        <color_code>#ffc924</color_code>
     </metadata>
     <properties>
         <density>1.24</density>

--- a/polyflex_pla.xml.fdm_material
+++ b/polyflex_pla.xml.fdm_material
@@ -2,7 +2,8 @@
 <fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
     <metadata>
         <name>
-            <brand>PolyFlex</brand>
+            <brand>Polymaker</brand>
+            <label>PolyFlex</label>
             <material>PLA</material>
             <color>Generic</color>
         </name>

--- a/polymax_pla.xml.fdm_material
+++ b/polymax_pla.xml.fdm_material
@@ -2,7 +2,8 @@
 <fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
     <metadata>
         <name>
-            <brand>PolyMax</brand>
+            <brand>Polymaker</brand>
+            <label>PolyMax</label>
             <material>PLA</material>
             <color>Generic</color>
         </name>

--- a/polyplus_pla.xml.fdm_material
+++ b/polyplus_pla.xml.fdm_material
@@ -2,7 +2,8 @@
 <fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
     <metadata>
         <name>
-            <brand>PolyPlus</brand>
+            <brand>Polymaker</brand>
+            <label>PolyPlus</label>
             <material>PLA</material>
             <color>Generic</color>
         </name>

--- a/polywood_pla.xml.fdm_material
+++ b/polywood_pla.xml.fdm_material
@@ -2,7 +2,8 @@
 <fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
     <metadata>
         <name>
-            <brand>PolyWood</brand>
+            <brand>Polymaker</brand>
+            <label>PolyWood</label>
             <material>PLA</material>
             <color>Generic</color>
         </name>


### PR DESCRIPTION
This PR fixes some issues with 1.75mm materials in the repo:
* adds the missing color_code to the Chromatik PLA (which caused issues in Cura)
* groups the different Polymaker PLA variations into a single Polymaker brand