### PR TITLE
Changing Cartesio hotend id`s

### DIFF
--- a/dsm_arnitel2045_175.xml.fdm_material
+++ b/dsm_arnitel2045_175.xml.fdm_material
@@ -39,6 +39,18 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/dsm_novamid1070_175.xml.fdm_material
+++ b/dsm_novamid1070_175.xml.fdm_material
@@ -16,17 +16,17 @@
         <diameter>1.75</diameter>
     </properties>
     <settings>
-        <setting key="print temperature">270</setting>
-        <setting key="heated bed temperature">85</setting>
-        <setting key="standby temperature">160</setting>
+        <setting key="print temperature">255</setting>
+        <setting key="heated bed temperature">75</setting>
+        <setting key="standby temperature">220</setting>
 
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
-            <setting key="print cooling">40.0</setting>
-            <setting key="standby temperature">160</setting>
+            <setting key="print cooling">0.0</setting>
+            <setting key="standby temperature">220</setting>
             <setting key="retraction speed">20</setting>
-            <setting key="heated bed temperature">85</setting>
-            <setting key="print temperature">270</setting>
+            <setting key="heated bed temperature">75</setting>
+            <setting key="print temperature">255</setting>
             <hotend id="0.25 mm">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.0</setting>
@@ -36,6 +36,18 @@
                 <setting key="retraction amount">1.0</setting>
             </hotend>
             <hotend id="0.8 mm">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>

--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -43,6 +43,18 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
         </machine>
    </settings>
 </fdmmaterial>

--- a/generic_hips_175.xml.fdm_material
+++ b/generic_hips_175.xml.fdm_material
@@ -41,6 +41,18 @@ Generic HIPS 1.75mm profile. The data in this file may not be correct for your s
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
        </machine>
     </settings>
 </fdmmaterial>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -45,6 +45,18 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
        </machine>
     </settings>
 </fdmmaterial>

--- a/generic_pc_175.xml.fdm_material
+++ b/generic_pc_175.xml.fdm_material
@@ -43,6 +43,18 @@ Generic PC profile. The data in this file may not be correct for your specific m
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -53,6 +53,18 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -54,6 +54,18 @@ Generic PLA 1.75mm profile. The data in this file may not be correct for your sp
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -43,6 +43,18 @@ Generic PVA profile. The data in this file may not be correct for your specific 
                 <setting key="hardware compatible">yes</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
Add new hotend IDs for cartesio.
After this has been merged we will change variant names and quality
files in Cura.
After that we will delete old hotend IDs in materials.
We do this so we will not get broken links between materials and Cura