### PR TITLE
Add ZYYX materials.

### DIFF
--- a/zyyx_pro_flex.xml.fdm_material
+++ b/zyyx_pro_flex.xml.fdm_material
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+  <metadata>
+    <name>
+      <brand>ZYYX</brand>
+      <material>TPU</material>
+      <color>Generic</color>
+      <label>proFlex</label>
+    </name>
+    <adhesion_info>Use with ZYYX standard build plate</adhesion_info>
+    <description>Fast, safe and reliable printing. ZYYX proFlex is ideal for flexible parts or soft grip parts.</description>
+    <version>1</version>
+    <color_code>#c0c0c0</color_code>
+    <GUID>182d2e1d-02cf-4208-b5e7-08607d0af2d8</GUID>
+  </metadata>
+  <properties>
+    <density>1.2</density>
+    <diameter>1.75</diameter>
+  </properties>
+  <settings>
+    <setting key="print temperature">230</setting>
+    <setting key="heated bed temperature">0</setting>
+    <setting key="standby temperature">200</setting>
+    <setting key="print cooling">100</setting>
+  </settings>
+</fdmmaterial>

--- a/zyyx_pro_pla.xml.fdm_material
+++ b/zyyx_pro_pla.xml.fdm_material
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+  <metadata>
+    <name>
+      <brand>ZYYX</brand>
+      <material>PLA</material>
+      <color>Generic</color>
+      <label>proPLA</label>
+    </name>
+    <adhesion_info>Use with ZYYX standard build plate</adhesion_info>
+    <description>Fast, safe and reliable printing. ZYYX proPLA is ideal for printing parts and prototypes with a great surface quality.</description>
+    <version>1</version>
+    <color_code>#ffc924</color_code>
+    <GUID>cece7f55-2ccc-4807-bbb6-4a5df9c9df81</GUID>
+  </metadata>
+  <properties>
+    <density>1.24</density>
+    <diameter>1.75</diameter>
+  </properties>
+  <settings>
+    <setting key="print temperature">210</setting>
+    <setting key="heated bed temperature">0</setting>
+    <setting key="standby temperature">200</setting>
+    <setting key="print cooling">100</setting>
+  </settings>
+</fdmmaterial>


### PR DESCRIPTION
Hi!

This pull adds two filaments sold by Magicfirm Europe to go with their ZYYX line of printers, it's a companion to the https://github.com/Ultimaker/Cura/pull/3584 pull in the main Cura repo.

If it's not to late I'd love if it can be merged into the upcoming 3.3 release, otherwise master will do.