### PR TITLE
CURA-5444 Set PVAs to be hardware compatible by default

### DIFF
--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>86a89ceb-4159-47f6-ab97-e9953803d70f</GUID>
-        <version>6</version>
+        <version>7</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -20,7 +20,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="hardware compatible">no</setting>
+        <setting key="hardware compatible">yes</setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
 

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -20,23 +20,16 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="hardware compatible">yes</setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
-            <setting key="hardware compatible">no</setting>
-        </machine>
-
-        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original Dual Extrusion"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
             <setting key="hardware compatible">no</setting>
-            <hotend id="0.25 mm" />
-            <hotend id="0.4 mm" />
-            <hotend id="0.6 mm" />
-            <hotend id="0.8 mm" />
         </machine>
 
         <machine>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -25,6 +25,21 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="standby temperature">175</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="hardware compatible">no</setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="hardware compatible">no</setting>
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>a4255da2-cb2a-4042-be49-4a83957a2f9a</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -20,7 +20,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <diameter>1.75</diameter>
     </properties>
     <settings>
-        <setting key="hardware compatible">no</setting>
+        <setting key="hardware compatible">yes</setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
 

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -20,7 +20,6 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <diameter>1.75</diameter>
     </properties>
     <settings>
-        <setting key="hardware compatible">yes</setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
 

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -47,23 +47,16 @@
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="hardware compatible">yes</setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
-            <setting key="hardware compatible">no</setting>
-        </machine>
-
-        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original Dual Extrusion"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
             <setting key="hardware compatible">no</setting>
-            <hotend id="0.25 mm" />
-            <hotend id="0.4 mm" />
-            <hotend id="0.6 mm" />
-            <hotend id="0.8 mm" />
         </machine>
 
         <machine>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -52,6 +52,21 @@
         <setting key="standby temperature">175</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="hardware compatible">no</setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="hardware compatible">no</setting>
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Natural</color>
         </name>
         <GUID>fe15ed8a-33c3-4f57-a2a7-b4b78a38c3cb</GUID>
-        <version>6</version>
+        <version>7</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -47,7 +47,7 @@
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="hardware compatible">no</setting>
+        <setting key="hardware compatible">yes</setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
 


### PR DESCRIPTION
Otherwise you can never print with PVA on 3rd-party printers.