### PR TITLE
CPE+ fixed retraction length in generic profile

### DIFF
--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
-        <version>11</version>
+        <version>12</version>
         <color_code>#3633F2</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -77,7 +77,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">110</setting>
                 <setting key="standby temperature">100</setting>
-                <setting key="retraction amount">10</setting>
+                <setting key="retraction amount">8</setting>
                 <setting key="retraction speed">40</setting>
                 <setting key="print cooling">1</setting>
             </hotend>


### PR DESCRIPTION
CURA-4877 : one setting change was forgotten, making our Ultimaker material profiles deviate from the Generic ones.
( a4e54c4 )