### PR TITLE
Remove an obsolete TODO remark

### DIFF
--- a/generic_bam.xml.fdm_material
+++ b/generic_bam.xml.fdm_material
@@ -11,9 +11,9 @@ Generic break away support material profile. The data in this file may not be co
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d6a0</GUID>
         <version>13</version>
-        <color_code>#f1ece1</color_code> <!--TODO EM-1863 -->
+        <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
-        <adhesion_info>same temperature/method as build material</adhesion_info> <!--TODO EM-1863 -->
+        <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
     </metadata>
     <properties>
         <density>1.22</density>

--- a/ultimaker_bam.xml.fdm_material
+++ b/ultimaker_bam.xml.fdm_material
@@ -8,9 +8,9 @@
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d5f9</GUID>
         <version>15</version>
-        <color_code>#f1ece1</color_code> <!--TODO EM-1863 -->
+        <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
-        <adhesion_info>same temperature/method as build material</adhesion_info> <!--TODO EM-1863 -->
+        <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
     </metadata>
     <properties>
         <density>1.22</density>


### PR DESCRIPTION
Update the wording in the adhesion text (using same text as in the PVA material).
Didn't update the version number since it is only a textual change.

EM-1863