### PR TITLE
Add values for the build volume temperature

### DIFF
--- a/Vertex_Delta_ABS.xml.fdm_material
+++ b/Vertex_Delta_ABS.xml.fdm_material
@@ -10,7 +10,7 @@
         <color_code>#ffc924</color_code>
         <GUID>4edd8fce-0851-43e5-808a-970b4bfe8b10</GUID>
         <adhesion_info />
-        <version>3</version>
+        <version>4</version>
         <description />
     </metadata>
     <properties>
@@ -23,6 +23,7 @@
         <setting key="retraction amount">3.0</setting>
         <setting key="print temperature">250.0</setting>
         <setting key="heated bed temperature">0.0</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="retraction speed">150.0</setting>
     </settings>
 </fdmmaterial>

--- a/Vertex_Delta_TPU.xml.fdm_material
+++ b/Vertex_Delta_TPU.xml.fdm_material
@@ -10,7 +10,7 @@
         <color_code>#ffc924</color_code>
         <GUID>a5ab90e5-9f5d-445b-b0c5-5312dafa2e27</GUID>
         <adhesion_info />
-        <version>3</version>
+        <version>4</version>
         <description />
     </metadata>
     <properties>
@@ -23,6 +23,7 @@
         <setting key="retraction amount">3.0</setting>
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">0.0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="retraction speed">150.0</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_abs.xml.fdm_material
+++ b/fabtotum_abs.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>956b9054-e5e8-4852-8f5b-1332b73fcd07</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#8CB219</color_code>
         <description>FABtotum generic ABS profile.</description>
         <adhesion_info>Recommended nozzle temperature: 250...260C, bed temperature: 90...100C, layer fan: off...50%, adhesion type: raft.</adhesion_info>
@@ -19,5 +19,6 @@
     <settings>
         <setting key="print temperature">250.0</setting>
         <setting key="heated bed temperature">95.0</setting>
+        <setting key="build volume temperature">45</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_nylon.xml.fdm_material
+++ b/fabtotum_nylon.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>68c674d6-1289-4a44-8d69-e8a2b1a49855</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#3DF266</color_code>
         <description>FABtotum generic Nylon profile.</description>
         <adhesion_info>Recommended nozzle temperature: 230...240C, bed temperature: 80...90C, layer fan: off, adhesion type: raft.</adhesion_info>
@@ -19,5 +19,6 @@
     <settings>
         <setting key="print temperature">240.0</setting>
         <setting key="heated bed temperature">90.0</setting>
+        <setting key="build volume temperature">40</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_tpu.xml.fdm_material
+++ b/fabtotum_tpu.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>97e6aaf1-0da2-47f8-a473-16b8b485bcf5</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#B22744</color_code>
         <description>FABtotum TPU Black profile.</description>
         <adhesion_info>Recommended nozzle temperature: 210...220C, bed temperature: 40...50C, layer fan: on, adhesion type: skirt.</adhesion_info>
@@ -19,5 +19,6 @@
     <settings>
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">40.0</setting>
+        <setting key="build volume temperature">32</setting>
     </settings>
 </fdmmaterial>

--- a/fiberlogy_hd_pla.xml.fdm_material
+++ b/fiberlogy_hd_pla.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>78f8b7d3-e129-4ba3-bdb1-1c9eed8a923f</GUID>
-        <version>1</version>
+        <version>2</version>
         <color_code>#dba500</color_code>
     </metadata>
     <properties>
@@ -16,5 +16,6 @@
     </properties>
     <settings>
         <setting key="print temperature">210</setting>
+        <setting key="build volume temperature">33</setting>
     </settings>
 </fdmmaterial>

--- a/generic_abs.xml.fdm_material
+++ b/generic_abs.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>60636bb4-518f-42e7-8237-fe77b194ebe0</GUID>
-        <version>13</version>
+        <version>14</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -22,6 +22,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>2780b345-577b-4a24-a2c5-12e6aad3e690</GUID>
-        <version>5</version>
+        <version>6</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -22,6 +22,7 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/generic_bam.xml.fdm_material
+++ b/generic_bam.xml.fdm_material
@@ -10,7 +10,7 @@ Generic break away support material profile. The data in this file may not be co
             <color>Generic</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d6a0</GUID>
-        <version>13</version>
+        <version>14</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -36,6 +36,7 @@ Generic break away support material profile. The data in this file may not be co
         <setting key="end of filament purge length">80</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">100</setting>
 
         <!-- For material flow sensor -->

--- a/generic_cffcpe.xml.fdm_material
+++ b/generic_cffcpe.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print 
             <color>Generic</color>
         </name>
         <GUID>f8e496d6-7599-4015-9fac-c7ce53f6633c</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#212F3D</color_code>
         <description>This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print Profile Assistant. This profile can also be used for other base materials (ABS, PP, etc)</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print 
     <settings>
         <setting key="print temperature">265</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/generic_cffpa.xml.fdm_material
+++ b/generic_cffpa.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Pr
             <color>Generic</color>
         </name>
         <GUID>bd66b243-9d50-4e12-bfc3-51c874fca16a</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#212F3D</color_code>
         <description>This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Profile Assistant.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Pr
     <settings>
         <setting key="print temperature">265</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">40</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>

--- a/generic_cpe.xml.fdm_material
+++ b/generic_cpe.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>12f41353-1a33-415e-8b4f-a775a6c70cc6</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#159499</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -36,6 +36,7 @@ Generic CPE profile. The data in this file may not be correct for your specific 
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/generic_cpe_175.xml.fdm_material
+++ b/generic_cpe_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>da1872c1-b991-4795-80ad-bdac0f131726</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#159499</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ Generic CPE 1.75mm profile. The data in this file may not be correct for your sp
     <settings>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#3633F2</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -36,6 +36,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">260</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/generic_gffcpe.xml.fdm_material
+++ b/generic_gffcpe.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Glass Fiber Filled Copolyesters for the Print P
             <color>Generic</color>
         </name>
         <GUID>d4b786bb-e5d2-481b-b3ab-0be976d36af8</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#D5D8DC</color_code>
         <description>This is the baseline profile for Glass Fiber Filled Copolyesters for the Print Profile Assistant. This profile can also be used for other base materials (ABS, PP, etc)</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ This is the baseline profile for Glass Fiber Filled Copolyesters for the Print P
     <settings>
         <setting key="print temperature">265</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/generic_gffpa.xml.fdm_material
+++ b/generic_gffpa.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Glass Fiber Filled Polyamides for the Print Pro
             <color>Generic</color>
         </name>
         <GUID>837cf11b-6b1e-48dc-94dc-4a2b4888648e</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#D5D8DC</color_code>
         <description>This is the baseline profile for Glass Fiber Filled Polyamides for the Print Profile Assistant.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ This is the baseline profile for Glass Fiber Filled Polyamides for the Print Pro
     <settings>
         <setting key="print temperature">265</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">40</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <color>Generic</color>
         </name>
         <GUID>28fb4162-db74-49e1-9008-d05f1e8bef5c</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -36,6 +36,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">245</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">40</setting>
         <setting key="standby temperature">175</setting>
         <setting key="retraction amount">8</setting>
         <setting key="retraction speed">25</setting>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
             <color>Generic</color>
         </name>
         <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
-        <version>3</version>
+        <version>4</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
     <settings>
         <setting key="print temperature">245</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">40</setting>
         <setting key="standby temperature">175</setting>
         <setting key="retraction amount">8</setting>
         <setting key="retraction speed">25</setting>

--- a/generic_pc.xml.fdm_material
+++ b/generic_pc.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
             <color>Generic</color>
         </name>
         <GUID>98c05714-bf4e-4455-ba27-57d74fe331e4</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -36,6 +36,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">270</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/generic_pc_175.xml.fdm_material
+++ b/generic_pc_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
             <color>Generic</color>
         </name>
         <GUID>62414577-94d1-490d-b1e4-7ef3ec40db02</GUID>
-        <version>3</version>
+        <version>4</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -22,6 +22,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
     <settings>
         <setting key="print temperature">270</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
 
         <machine>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
             <color>Generic</color>
         </name>
         <GUID>aa22e9c7-421f-4745-afc2-81851694394a</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#85f9de</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -36,6 +36,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">220</setting>
         <setting key="heated bed temperature">100</setting>
+        <setting key="build volume temperature">41</setting>
         <setting key="standby temperature">185</setting>
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>86a89ceb-4159-47f6-ab97-e9953803d70f</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -35,6 +35,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="flush purge length">60<!--?--></setting>
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
 
         <!-- For material flow sensor -->

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>a4255da2-cb2a-4042-be49-4a83957a2f9a</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -21,6 +21,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
     </properties>
     <settings>
         <setting key="print temperature">215</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
 
         <machine>

--- a/generic_tough_pla.xml.fdm_material
+++ b/generic_tough_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>9d5d2d7c-4e77-441c-85a0-e9eefd4aa68c</GUID>
-        <version>8</version>
+        <version>9</version>
         <color_code>#ffc9f0</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -36,6 +36,7 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">33</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">100</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -10,7 +10,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
             <color>Generic</color>
         </name>
         <GUID>1d52b2be-a3a2-41de-a8b1-3bcdb5618695</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -36,6 +36,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>

--- a/generic_tpu_175.xml.fdm_material
+++ b/generic_tpu_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
             <color>Generic</color>
         </name>
         <GUID>19baa6a9-94ff-478b-b4a1-8157b74358d2</GUID>
-        <version>9</version>
+        <version>10</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -22,6 +22,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
     <settings>
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>

--- a/innofill_innoflex60_175.xml.fdm_material
+++ b/innofill_innoflex60_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>093c0407-a7ab-4772-a2a1-4c52677f11d3</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#ecece7</color_code>
         <description>Shore-A hardness of 60. Suitable for applications that require flexibility.</description>
     </metadata>
@@ -17,5 +17,6 @@
     </properties>
     <settings>
         <setting key="print temperature">220</setting>
+        <setting key="build volume temperature">32</setting>
     </settings>
 </fdmmaterial>

--- a/structur3d_dap100silicone.xml.fdm_material
+++ b/structur3d_dap100silicone.xml.fdm_material
@@ -10,8 +10,7 @@
     <definition>fdmprinter</definition>
     <adhesion_info>Print on wax paper. Use tape to affix wax paper to bed.</adhesion_info>
     <color_code>#057ec7</color_code>
-    <version>12</version>
-    <compatible>True</compatible>
+    <version>13</version>
     <GUID>9bce7bd3-53fd-467a-8b92-0d70720683d9</GUID>
     <description>Safe and reliable silicone printing. DAP 100% Silicone is ideal for the printing of parts and prototypes with flexibility, compressibility, as well as chemical and temperature resistance. Cure time is several minutes to hours.</description>
   </metadata>

--- a/structur3d_dap100silicone.xml.fdm_material
+++ b/structur3d_dap100silicone.xml.fdm_material
@@ -1,56 +1,56 @@
 <?xml version='1.0' encoding='utf-8'?>
 <fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura">
-  <metadata>
-    <name>
-      <brand>Structur3d</brand>
-      <material>Silicone</material>
-      <color>Clear</color>
-      <label>DAP 100% Silicone</label>
-    </name>
-    <definition>fdmprinter</definition>
-    <adhesion_info>Print on wax paper. Use tape to affix wax paper to bed.</adhesion_info>
-    <color_code>#057ec7</color_code>
-    <version>13</version>
-    <GUID>9bce7bd3-53fd-467a-8b92-0d70720683d9</GUID>
-    <description>Safe and reliable silicone printing. DAP 100% Silicone is ideal for the printing of parts and prototypes with flexibility, compressibility, as well as chemical and temperature resistance. Cure time is several minutes to hours.</description>
-  </metadata>
-  <properties>
-    <diameter>3.175</diameter>
-    <density>1</density>
-  </properties>
-  <settings>
-    <setting key="adhesion tendency">0</setting>
-    <setting key="retraction amount">0.0</setting>
-    <setting key="surface energy">100</setting>
-    <setting key="print temperature">0.0</setting>
-    <setting key="standby temperature">0.0</setting>
-    <setting key="heated bed temperature">0.0</setting>
-    <setting key="print cooling">0.0</setting>
-    <setting key="hardware compatible">no</setting>
-    <machine>
-      <machine_identifier manufacturer="Structur3d.io" product="structur3d_discov3ry1_complete_um2plus" />
-      <setting key="hardware compatible">yes</setting>
-      <hotend id="0.20mm (Clear)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-      <hotend id="0.25mm (Red)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-      <hotend id="0.41mm (Blue)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-      <hotend id="0.58mm (Pink)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-      <hotend id="0.84mm (Green)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-      <hotend id="1.19mm (Grey)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-      <hotend id="1.60mm (Olive)">
-        <setting key="hardware compatible">yes</setting>
-      </hotend>
-    </machine>
-  </settings>
+    <metadata>
+        <name>
+            <brand>Structur3d</brand>
+            <material>Silicone</material>
+            <color>Clear</color>
+            <label>DAP 100% Silicone</label>
+        </name>
+        <definition>fdmprinter</definition>
+        <adhesion_info>Print on wax paper. Use tape to affix wax paper to bed.</adhesion_info>
+        <color_code>#057ec7</color_code>
+        <version>13</version>
+        <GUID>9bce7bd3-53fd-467a-8b92-0d70720683d9</GUID>
+        <description>Safe and reliable silicone printing. DAP 100% Silicone is ideal for the printing of parts and prototypes with flexibility, compressibility, as well as chemical and temperature resistance. Cure time is several minutes to hours.</description>
+    </metadata>
+    <properties>
+        <diameter>3.175</diameter>
+        <density>1</density>
+    </properties>
+    <settings>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="retraction amount">0.0</setting>
+        <setting key="surface energy">100</setting>
+        <setting key="print temperature">0.0</setting>
+        <setting key="standby temperature">0.0</setting>
+        <setting key="heated bed temperature">0.0</setting>
+        <setting key="print cooling">0.0</setting>
+        <setting key="hardware compatible">no</setting>
+        <machine>
+            <machine_identifier manufacturer="Structur3d.io" product="structur3d_discov3ry1_complete_um2plus" />
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.20mm (Clear)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="0.25mm (Red)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="0.41mm (Blue)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="0.58mm (Pink)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="0.84mm (Green)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="1.19mm (Grey)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="1.60mm (Olive)">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+    </settings>
 </fdmmaterial>

--- a/tizyx_abs.xml.fdm_material
+++ b/tizyx_abs.xml.fdm_material
@@ -1,48 +1,49 @@
 <?xml version='1.0' encoding='utf-8'?>
 <fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
-  <metadata>
-    <name>
-      <brand>TiZYX</brand>
-      <material>ABS</material>
-      <color>Generic</color>
-      <label>ABS TiZYX</label>
-    </name>
-    <version>3</version>
-    <color_code>#0097e8</color_code>
-    <GUID>ae03b4fd-2aa6-4957-aaea-b7ca0bbf0370</GUID>
-    <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
-    <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
-  </metadata>
-  <properties>
-    <diameter>1.75</diameter>
-    <density>1.10</density>
-  </properties>
-  <settings>
-    <setting key="print temperature">235.0</setting>
-    <setting key="standby temperature">200</setting>
-    <setting key="print cooling">10.0</setting>
-    <setting key="heated bed temperature">95.0</setting>
-    <setting key="retraction amount">2.5</setting>
-    <machine>
-      <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
-      <setting key="heated bed temperature">90</setting>
-      <setting key="print temperature">230</setting>
-      <setting key="standby temperature">160</setting>
-      <setting key="print cooling">0.0</setting>
-      <setting key="retraction speed">40</setting>
-      <setting key="retraction amount">4.0</setting>
-      <hotend id="0.4mm thermoplastic extruder">
-        <setting key="hardware compatible">yes</setting>
-        <setting key="retraction amount">1.0</setting>
-      </hotend>
-      <hotend id="0.25mm thermoplastic extruder">
-        <setting key="hardware compatible">yes</setting>
-        <setting key="retraction amount">1.0</setting>
-      </hotend>
-      <hotend id="0.8mm thermoplastic extruder">
-        <setting key="hardware compatible">yes</setting>
-        <setting key="retraction amount">1.5</setting>
-      </hotend>
-    </machine>
-  </settings>
+    <metadata>
+        <name>
+            <brand>TiZYX</brand>
+            <material>ABS</material>
+            <color>Generic</color>
+            <label>ABS TiZYX</label>
+        </name>
+        <version>4</version>
+        <color_code>#0097e8</color_code>
+        <GUID>ae03b4fd-2aa6-4957-aaea-b7ca0bbf0370</GUID>
+        <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
+        <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
+    </metadata>
+    <properties>
+        <diameter>1.75</diameter>
+        <density>1.10</density>
+    </properties>
+    <settings>
+        <setting key="print temperature">235.0</setting>
+        <setting key="standby temperature">200</setting>
+        <setting key="print cooling">10.0</setting>
+        <setting key="heated bed temperature">95.0</setting>
+        <setting key="build volume temperature">45</setting>
+        <setting key="retraction amount">2.5</setting>
+        <machine>
+            <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
+            <setting key="heated bed temperature">90</setting>
+            <setting key="print temperature">230</setting>
+            <setting key="standby temperature">160</setting>
+            <setting key="print cooling">0.0</setting>
+            <setting key="retraction speed">40</setting>
+            <setting key="retraction amount">4.0</setting>
+            <hotend id="0.4mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.25mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.0</setting>
+            </hotend>
+            <hotend id="0.8mm thermoplastic extruder">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
+        </machine>
+    </settings>
 </fdmmaterial>

--- a/ultimaker_abs_black.xml.fdm_material
+++ b/ultimaker_abs_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>2f9d2279-9b0e-4765-bf9b-d1e1e13f3c49</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#2a292a</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_blue.xml.fdm_material
+++ b/ultimaker_abs_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>7c9575a6-c8d6-40ec-b3dd-18d7956bfaae</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#00387b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_green.xml.fdm_material
+++ b/ultimaker_abs_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>3400c0d1-a4e3-47de-a444-7b704f287171</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#61993b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_grey.xml.fdm_material
+++ b/ultimaker_abs_grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Grey</color>
         </name>
         <GUID>8b75b775-d3f2-4d0f-8fb2-2a3dd53cf673</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#52595d</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_orange.xml.fdm_material
+++ b/ultimaker_abs_orange.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>0b4ca6ef-eac8-4b23-b3ca-5f21af00e54f</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#ed6b21</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_pearl-gold.xml.fdm_material
+++ b/ultimaker_abs_pearl-gold.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Pearl Gold</color>
         </name>
         <GUID>7cbdb9ca-081a-456f-a6ba-f73e4e9cb856</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#80643f</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_red.xml.fdm_material
+++ b/ultimaker_abs_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>5df7afa6-48bd-4c19-b314-839fe9f08f1f</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#bb1e10</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_silver-metallic.xml.fdm_material
+++ b/ultimaker_abs_silver-metallic.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Silver Metallic</color>
         </name>
         <GUID>763c926e-a5f7-4ba0-927d-b4e038ea2735</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#a1a1a0</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_white.xml.fdm_material
+++ b/ultimaker_abs_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5253a75a-27dc-4043-910f-753ae11bc417</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#ecece7</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_abs_yellow.xml.fdm_material
+++ b/ultimaker_abs_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>e873341d-d9b8-45f9-9a6f-5609e1bcff68</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#f7b500</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -21,6 +21,7 @@
     <settings>
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_bam.xml.fdm_material
+++ b/ultimaker_bam.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d5f9</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">80</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">100</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_cpe_black.xml.fdm_material
+++ b/ultimaker_cpe_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>a8955dc3-9d7e-404d-8c03-0fd6fee7f22d</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#2a292a</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_blue.xml.fdm_material
+++ b/ultimaker_cpe_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>4d816290-ce2e-40e0-8dc8-3f702243131e</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#00a3e0</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_dark-grey.xml.fdm_material
+++ b/ultimaker_cpe_dark-grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Dark Grey</color>
         </name>
         <GUID>10961c00-3caf-48e9-a598-fa805ada1e8d</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#4f5250</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_green.xml.fdm_material
+++ b/ultimaker_cpe_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>7ff6d2c8-d626-48cd-8012-7725fa537cc9</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#78be20</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_light-grey.xml.fdm_material
+++ b/ultimaker_cpe_light-grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Light Grey</color>
         </name>
         <GUID>173a7bae-5e14-470e-817e-08609c61e12b</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#c5c7c4</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_plus_black.xml.fdm_material
+++ b/ultimaker_cpe_plus_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>1aca047a-42df-497c-abfb-0e9cb85ead52</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#0e0e10</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">260</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/ultimaker_cpe_plus_transparent.xml.fdm_material
+++ b/ultimaker_cpe_plus_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>a9c340fe-255f-4914-87f5-ec4fcb0c11ef</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">260</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/ultimaker_cpe_plus_white.xml.fdm_material
+++ b/ultimaker_cpe_plus_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6df69b13-2d96-4a69-a297-aedba667e710</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">260</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/ultimaker_cpe_red.xml.fdm_material
+++ b/ultimaker_cpe_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>00181d6c-7024-479a-8eb7-8a2e38a2619a</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#c8102e</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_transparent.xml.fdm_material
+++ b/ultimaker_cpe_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>bd0d9eb3-a920-4632-84e8-dcd6086746c5</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_white.xml.fdm_material
+++ b/ultimaker_cpe_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>881c888e-24fb-4a64-a4ac-d5c95b096cd7</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_cpe_yellow.xml.fdm_material
+++ b/ultimaker_cpe_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>b9176a2a-7a0f-4821-9f29-76d882a88682</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#f6b600</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">70</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>c64c2dbe-5691-4363-a7d9-66b2dc12837f</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#27292b</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">245</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">40</setting>
         <setting key="standby temperature">175</setting>
         <setting key="retraction amount">8</setting>
         <setting key="retraction speed">25</setting>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>e256615d-a04e-4f53-b311-114b90560af9</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#d0d0d0</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">245</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">40</setting>
         <setting key="standby temperature">175</setting>
         <setting key="retraction amount">8</setting>
         <setting key="retraction speed">25</setting>

--- a/ultimaker_pc_black.xml.fdm_material
+++ b/ultimaker_pc_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>e92b1f0b-a069-4969-86b4-30127cfb6f7b</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#0e0e10</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">270</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/ultimaker_pc_transparent.xml.fdm_material
+++ b/ultimaker_pc_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>8a38a3e9-ecf7-4a7d-a6a9-e7ac35102968</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#d0d0d0</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">270</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5e786b05-a620-4a87-92d0-f02becc1ff98</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#ecece7</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">270</setting>
         <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">50</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>

--- a/ultimaker_pp_transparent.xml.fdm_material
+++ b/ultimaker_pp_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>c7005925-2a41-4280-8cdd-4029e3fe5253</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#d0d0d0</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">220</setting>
         <setting key="heated bed temperature">100</setting>
+        <setting key="build volume temperature">41</setting>
         <setting key="standby temperature">185</setting>
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Natural</color>
         </name>
         <GUID>fe15ed8a-33c3-4f57-a2a7-b4b78a38c3cb</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -61,6 +61,7 @@
         <setting key="flush purge length">60<!--?--></setting>
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
+        <setting key="build volume temperature">45</setting>
         <setting key="standby temperature">175</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_tough_pla_black.xml.fdm_material
+++ b/ultimaker_tough_pla_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>03f24266-0291-43c2-a6da-5211892a2699</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#2a292a</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">33</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tough_pla_green.xml.fdm_material
+++ b/ultimaker_tough_pla_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>6d71f4ad-29ab-4b50-8f65-22d99af294dd</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#00a95c</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">33</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tough_pla_red.xml.fdm_material
+++ b/ultimaker_tough_pla_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>2db25566-9a91-4145-84a5-46c90ed22bdf</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#de4343</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">33</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tough_pla_white.xml.fdm_material
+++ b/ultimaker_tough_pla_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>851427a0-0c9a-4d7c-a9a8-5cc92f84af1f</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#ecece7</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">20</setting>
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">33</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>eff40bcf-588d-420d-a3bc-a5ffd8c7f4b3</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#0e0e10</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>5f4a826c-7bfe-460f-8650-a9178b180d34</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#00387b</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>07a4547f-d21f-41a0-8eee-bc92125221b3</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#a63437</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6a2573e6-c8ee-4c66-8029-3ebb3d5adc5b</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#f1ece1</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -35,6 +35,7 @@
         <setting key="end of filament purge length">10</setting>
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>

--- a/zyyx_pro_flex.xml.fdm_material
+++ b/zyyx_pro_flex.xml.fdm_material
@@ -1,26 +1,27 @@
 <?xml version='1.0' encoding='utf-8'?>
 <fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
-  <metadata>
-    <name>
-      <brand>ZYYX</brand>
-      <material>TPU</material>
-      <color>Generic</color>
-      <label>proFlex</label>
-    </name>
-    <adhesion_info>Use with ZYYX standard build plate</adhesion_info>
-    <description>Fast, safe and reliable printing. ZYYX proFlex is ideal for flexible parts or soft grip parts.</description>
-    <version>1</version>
-    <color_code>#c0c0c0</color_code>
-    <GUID>182d2e1d-02cf-4208-b5e7-08607d0af2d8</GUID>
-  </metadata>
-  <properties>
-    <density>1.2</density>
-    <diameter>1.75</diameter>
-  </properties>
-  <settings>
-    <setting key="print temperature">230</setting>
-    <setting key="heated bed temperature">0</setting>
-    <setting key="standby temperature">200</setting>
-    <setting key="print cooling">100</setting>
-  </settings>
+    <metadata>
+        <name>
+            <brand>ZYYX</brand>
+            <material>TPU</material>
+            <color>Generic</color>
+            <label>proFlex</label>
+        </name>
+        <adhesion_info>Use with ZYYX standard build plate</adhesion_info>
+        <description>Fast, safe and reliable printing. ZYYX proFlex is ideal for flexible parts or soft grip parts.</description>
+        <version>2</version>
+        <color_code>#c0c0c0</color_code>
+        <GUID>182d2e1d-02cf-4208-b5e7-08607d0af2d8</GUID>
+    </metadata>
+    <properties>
+        <density>1.2</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">230</setting>
+        <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">32</setting>
+        <setting key="standby temperature">200</setting>
+        <setting key="print cooling">100</setting>
+    </settings>
 </fdmmaterial>


### PR DESCRIPTION
This is based on the following table:
* PLA: 35 (not in these profiles as it is considered the default)
* ABS: 45
* BAM: 50
* CPE: 45
* CPE+: 50
* Nylon: 40
* PC: 50
* PP: 41
* PVA: 45
* TPLA: 33
* TPU: 32

Contributes to issue CURA-6514.