### PR TITLE
Add crystallinity values

### DIFF
--- a/Vertex_Delta_TPU.xml.fdm_material
+++ b/Vertex_Delta_TPU.xml.fdm_material
@@ -24,6 +24,6 @@
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">0.0</setting>
         <setting key="retraction speed">150.0</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/Vertex_Delta_TPU.xml.fdm_material
+++ b/Vertex_Delta_TPU.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura">
     <metadata>
         <name>
             <brand>Velleman</brand>

--- a/Vertex_Delta_TPU.xml.fdm_material
+++ b/Vertex_Delta_TPU.xml.fdm_material
@@ -10,7 +10,7 @@
         <color_code>#ffc924</color_code>
         <GUID>a5ab90e5-9f5d-445b-b0c5-5312dafa2e27</GUID>
         <adhesion_info />
-        <version>3</version>
+        <version>4</version>
         <description />
     </metadata>
     <properties>
@@ -24,5 +24,6 @@
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">0.0</setting>
         <setting key="retraction speed">150.0</setting>
+        <setting key="cura:material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/Vertex_Delta_TPU.xml.fdm_material
+++ b/Vertex_Delta_TPU.xml.fdm_material
@@ -24,6 +24,6 @@
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">0.0</setting>
         <setting key="retraction speed">150.0</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_nylon.xml.fdm_material
+++ b/fabtotum_nylon.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>68c674d6-1289-4a44-8d69-e8a2b1a49855</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#3DF266</color_code>
         <description>FABtotum generic Nylon profile.</description>
         <adhesion_info>Recommended nozzle temperature: 230...240C, bed temperature: 80...90C, layer fan: off, adhesion type: raft.</adhesion_info>
@@ -19,5 +19,6 @@
     <settings>
         <setting key="print temperature">240.0</setting>
         <setting key="heated bed temperature">90.0</setting>
+        <setting key="cura:material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_nylon.xml.fdm_material
+++ b/fabtotum_nylon.xml.fdm_material
@@ -19,6 +19,6 @@
     <settings>
         <setting key="print temperature">240.0</setting>
         <setting key="heated bed temperature">90.0</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_nylon.xml.fdm_material
+++ b/fabtotum_nylon.xml.fdm_material
@@ -19,6 +19,6 @@
     <settings>
         <setting key="print temperature">240.0</setting>
         <setting key="heated bed temperature">90.0</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_nylon.xml.fdm_material
+++ b/fabtotum_nylon.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>FABtotum</brand>

--- a/fabtotum_tpu.xml.fdm_material
+++ b/fabtotum_tpu.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>97e6aaf1-0da2-47f8-a473-16b8b485bcf5</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#B22744</color_code>
         <description>FABtotum TPU Black profile.</description>
         <adhesion_info>Recommended nozzle temperature: 210...220C, bed temperature: 40...50C, layer fan: on, adhesion type: skirt.</adhesion_info>
@@ -19,5 +19,6 @@
     <settings>
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">40.0</setting>
+        <setting key="cura:material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_tpu.xml.fdm_material
+++ b/fabtotum_tpu.xml.fdm_material
@@ -19,6 +19,6 @@
     <settings>
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">40.0</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_tpu.xml.fdm_material
+++ b/fabtotum_tpu.xml.fdm_material
@@ -19,6 +19,6 @@
     <settings>
         <setting key="print temperature">220.0</setting>
         <setting key="heated bed temperature">40.0</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/fabtotum_tpu.xml.fdm_material
+++ b/fabtotum_tpu.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>FABtotum</brand>

--- a/generic_bam.xml.fdm_material
+++ b/generic_bam.xml.fdm_material
@@ -10,7 +10,7 @@ Generic break away support material profile. The data in this file may not be co
             <color>Generic</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d6a0</GUID>
-        <version>13</version>
+        <version>14</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -20,12 +20,12 @@ Generic break away support material profile. The data in this file may not be co
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">-12</setting>
+        <setting key="break preparation retracted position">12</setting>
         <setting key="break preparation speed">25</setting>
         <setting key="break preparation temperature">225</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">85</setting>
         <setting key="break temperature">90</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_cffcpe.xml.fdm_material
+++ b/generic_cffcpe.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print 
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_cffcpe.xml.fdm_material
+++ b/generic_cffcpe.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print 
             <color>Generic</color>
         </name>
         <GUID>f8e496d6-7599-4015-9fac-c7ce53f6633c</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#212F3D</color_code>
         <description>This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print Profile Assistant. This profile can also be used for other base materials (ABS, PP, etc)</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -25,6 +25,7 @@ This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print 
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_cffcpe.xml.fdm_material
+++ b/generic_cffcpe.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print 
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_cffcpe.xml.fdm_material
+++ b/generic_cffcpe.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 This is the baseline profile for Carbon Fiber Filled Copolyesters for the Print Profile Assistant. This profile can also be used for other base materials (ABS, PP, etc)
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_cffpa.xml.fdm_material
+++ b/generic_cffpa.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Pr
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_cffpa.xml.fdm_material
+++ b/generic_cffpa.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Pr
             <color>Generic</color>
         </name>
         <GUID>bd66b243-9d50-4e12-bfc3-51c874fca16a</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#212F3D</color_code>
         <description>This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Profile Assistant.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -25,6 +25,7 @@ This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Pr
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_cffpa.xml.fdm_material
+++ b/generic_cffpa.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Pr
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_cffpa.xml.fdm_material
+++ b/generic_cffpa.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 This is the baseline profile for Carbon Fiber Filled Polyamides for the Print Profile Assistant.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_cpe.xml.fdm_material
+++ b/generic_cpe.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>12f41353-1a33-415e-8b4f-a775a6c70cc6</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#159499</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -20,12 +20,12 @@ Generic CPE profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#3633F2</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -20,12 +20,12 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">260</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_filled_pla.xml.fdm_material
+++ b/generic_filled_pla.xml.fdm_material
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Profile for PLA with fillers, such as woodfill or bronzefill. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+        </name>
+        <GUID>bb0b9ff7-05a8-464f-8eed-acb90df720f0</GUID>
+        <version>1</version>
+        <color_code>#996600</color_code>
+        <description>Filled PLA is still relatively easy to print, but can have a filler for a specific purpose, for the looks or weight or strength.</description>
+        <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
+    </metadata>
+    <properties>
+        <density>2.00</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retract speed">5</setting>
+        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation temperature">200</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">50</setting>
+        <setting key="maximum park duration">300</setting>
+        <setting key="no load move factor">0.940860215</setting>
+        <setting key="flush purge speed">10</setting>
+        <setting key="end of filament purge speed">10</setting>
+        <setting key="flush purge length">60</setting>
+        <setting key="end of filament purge length">20</setting>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">175</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">100</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended"/>
+            <setting key="standby temperature">150</setting>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="standby temperature">150</setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="print cooling">100</setting>
+            <hotend id="BB 0.4" />
+            <hotend id="BB 0.8" />
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="standby temperature">100</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <setting key="print cooling">100</setting>
+            <hotend id="BB 0.4" />
+            <hotend id="BB 0.8" />
+            <hotend id="CC 0.6">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="standby temperature">100</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="standby temperature">100</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="standby temperature">100</setting>
+                <setting key="retraction amount">5</setting>
+            </hotend>
+            <buildplate id="Glass">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="hardware recommended">yes</setting>
+            </buildplate>
+            <buildplate id="Aluminum">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="hardware recommended">no</setting>
+            </buildplate>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX"/>
+
+            <setting key="print temperature">210</setting>
+            <setting key="heated bed temperature">55</setting>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.4 mm 2-fans" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/generic_gffcpe.xml.fdm_material
+++ b/generic_gffcpe.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Glass Fiber Filled Copolyesters for the Print P
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_gffcpe.xml.fdm_material
+++ b/generic_gffcpe.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 This is the baseline profile for Glass Fiber Filled Copolyesters for the Print Profile Assistant. This profile can also be used for other base materials (ABS, PP, etc)
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_gffcpe.xml.fdm_material
+++ b/generic_gffcpe.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Glass Fiber Filled Copolyesters for the Print P
             <color>Generic</color>
         </name>
         <GUID>d4b786bb-e5d2-481b-b3ab-0be976d36af8</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#D5D8DC</color_code>
         <description>This is the baseline profile for Glass Fiber Filled Copolyesters for the Print Profile Assistant. This profile can also be used for other base materials (ABS, PP, etc)</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -25,6 +25,7 @@ This is the baseline profile for Glass Fiber Filled Copolyesters for the Print P
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_gffcpe.xml.fdm_material
+++ b/generic_gffcpe.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Glass Fiber Filled Copolyesters for the Print P
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_gffpa.xml.fdm_material
+++ b/generic_gffpa.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Glass Fiber Filled Polyamides for the Print Pro
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_gffpa.xml.fdm_material
+++ b/generic_gffpa.xml.fdm_material
@@ -25,7 +25,7 @@ This is the baseline profile for Glass Fiber Filled Polyamides for the Print Pro
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_gffpa.xml.fdm_material
+++ b/generic_gffpa.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 This is the baseline profile for Glass Fiber Filled Polyamides for the Print Profile Assistant.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_gffpa.xml.fdm_material
+++ b/generic_gffpa.xml.fdm_material
@@ -10,7 +10,7 @@ This is the baseline profile for Glass Fiber Filled Polyamides for the Print Pro
             <color>Generic</color>
         </name>
         <GUID>837cf11b-6b1e-48dc-94dc-4a2b4888648e</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#D5D8DC</color_code>
         <description>This is the baseline profile for Glass Fiber Filled Polyamides for the Print Profile Assistant.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -25,6 +25,7 @@ This is the baseline profile for Glass Fiber Filled Polyamides for the Print Pro
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <color>Generic</color>
         </name>
         <GUID>28fb4162-db74-49e1-9008-d05f1e8bef5c</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -41,6 +41,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -41,7 +41,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic Nylon profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -41,7 +41,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -20,12 +20,12 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">245</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">10</setting>
         <setting key="break temperature">140</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic Nylon 1.75mm profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -27,7 +27,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
             <color>Generic</color>
         </name>
         <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
-        <version>3</version>
+        <version>4</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -27,7 +27,8 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        
+        <setting key="cura:material_crystallinity">true</setting>
+
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
             <setting key="print cooling">0.0</setting>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -27,7 +27,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />

--- a/generic_pc.xml.fdm_material
+++ b/generic_pc.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
             <color>Generic</color>
         </name>
         <GUID>98c05714-bf4e-4455-ba27-57d74fe331e4</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -20,12 +20,12 @@ Generic PC profile. The data in this file may not be correct for your specific m
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">270</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -100,6 +100,7 @@ Generic PLA profile. The data in this file may not be correct for your specific 
                 <setting key="hardware compatible">yes</setting>
                 <setting key="standby temperature">100</setting>
                 <setting key="retraction amount">6.5</setting>
+                <cura:setting key="material_crystallinity">true</cura:setting>
             </hotend>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PLA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>506c9f0d-e3aa-4bd4-b2d2-23e2425b1aa9</GUID>
-        <version>13</version>
+        <version>14</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -20,12 +20,12 @@ Generic PLA profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic PLA profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -40,7 +40,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>
         <setting key="shrinkage percentage">2.5</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -20,12 +20,12 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <density>0.89</density>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">40</setting>
-        <setting key="break preparation position">-8</setting>
+        <setting key="break preparation retracted position">8</setting>
         <setting key="break preparation speed">17<!--?--></setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">17</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
             <color>Generic</color>
         </name>
         <GUID>aa22e9c7-421f-4745-afc2-81851694394a</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#85f9de</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -40,6 +40,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>
         <setting key="shrinkage percentage">2.5</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -40,7 +40,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>
         <setting key="shrinkage percentage">2.5</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic Polypropylene profile. Serves as an example file, data in this file is not correct.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic PVA profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -20,12 +20,12 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">215</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">10</setting>
         <setting key="break temperature">130</setting>
         <setting key="maximum park duration">60<!--?--></setting>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -36,7 +36,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -36,7 +36,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>86a89ceb-4159-47f6-ab97-e9953803d70f</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -36,6 +36,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -22,7 +22,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
     <settings>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic PVA profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -22,7 +22,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
     <settings>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>a4255da2-cb2a-4042-be49-4a83957a2f9a</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -22,6 +22,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
     <settings>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />

--- a/generic_tough_pla.xml.fdm_material
+++ b/generic_tough_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>9d5d2d7c-4e77-441c-85a0-e9eefd4aa68c</GUID>
-        <version>8</version>
+        <version>9</version>
         <color_code>#ffc9f0</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -20,12 +20,12 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -20,12 +20,12 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-6.5</setting>
+        <setting key="anti ooze retracted position">6.5</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">190</setting>
         <setting key="maximum park duration">300</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -39,7 +39,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -39,7 +39,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -10,7 +10,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
             <color>Generic</color>
         </name>
         <GUID>1d52b2be-a3a2-41de-a8b1-3bcdb5618695</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,6 +39,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic TPU 95A profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_tpu_175.xml.fdm_material
+++ b/generic_tpu_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
             <color>Generic</color>
         </name>
         <GUID>19baa6a9-94ff-478b-b4a1-8157b74358d2</GUID>
-        <version>9</version>
+        <version>10</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -25,5 +25,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
      </settings>
 </fdmmaterial>

--- a/generic_tpu_175.xml.fdm_material
+++ b/generic_tpu_175.xml.fdm_material
@@ -25,6 +25,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
      </settings>
 </fdmmaterial>

--- a/generic_tpu_175.xml.fdm_material
+++ b/generic_tpu_175.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic TPU 95A profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>

--- a/generic_tpu_175.xml.fdm_material
+++ b/generic_tpu_175.xml.fdm_material
@@ -25,6 +25,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
      </settings>
 </fdmmaterial>

--- a/innofill_innoflex60_175.xml.fdm_material
+++ b/innofill_innoflex60_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>093c0407-a7ab-4772-a2a1-4c52677f11d3</GUID>
-        <version>2</version>
+        <version>3</version>
         <color_code>#ecece7</color_code>
         <description>Shore-A hardness of 60. Suitable for applications that require flexibility.</description>
     </metadata>
@@ -17,5 +17,6 @@
     </properties>
     <settings>
         <setting key="print temperature">220</setting>
+        <setting key="cura:material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/innofill_innoflex60_175.xml.fdm_material
+++ b/innofill_innoflex60_175.xml.fdm_material
@@ -17,6 +17,6 @@
     </properties>
     <settings>
         <setting key="print temperature">220</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
     </settings>
 </fdmmaterial>

--- a/innofill_innoflex60_175.xml.fdm_material
+++ b/innofill_innoflex60_175.xml.fdm_material
@@ -17,6 +17,6 @@
     </properties>
     <settings>
         <setting key="print temperature">220</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>

--- a/innofill_innoflex60_175.xml.fdm_material
+++ b/innofill_innoflex60_175.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Innofill</brand>

--- a/ultimaker_bam.xml.fdm_material
+++ b/ultimaker_bam.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d5f9</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">-12</setting>
+        <setting key="break preparation retracted position">12</setting>
         <setting key="break preparation speed">25</setting>
         <setting key="break preparation temperature">225</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">85</setting>
         <setting key="break temperature">90</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_black.xml.fdm_material
+++ b/ultimaker_cpe_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>a8955dc3-9d7e-404d-8c03-0fd6fee7f22d</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#2a292a</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_blue.xml.fdm_material
+++ b/ultimaker_cpe_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>4d816290-ce2e-40e0-8dc8-3f702243131e</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#00a3e0</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_dark-grey.xml.fdm_material
+++ b/ultimaker_cpe_dark-grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Dark Grey</color>
         </name>
         <GUID>10961c00-3caf-48e9-a598-fa805ada1e8d</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#4f5250</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_green.xml.fdm_material
+++ b/ultimaker_cpe_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>7ff6d2c8-d626-48cd-8012-7725fa537cc9</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#78be20</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_light-grey.xml.fdm_material
+++ b/ultimaker_cpe_light-grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Light Grey</color>
         </name>
         <GUID>173a7bae-5e14-470e-817e-08609c61e12b</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#c5c7c4</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_plus_black.xml.fdm_material
+++ b/ultimaker_cpe_plus_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>1aca047a-42df-497c-abfb-0e9cb85ead52</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#0e0e10</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">260</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_plus_transparent.xml.fdm_material
+++ b/ultimaker_cpe_plus_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>a9c340fe-255f-4914-87f5-ec4fcb0c11ef</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">260</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_plus_white.xml.fdm_material
+++ b/ultimaker_cpe_plus_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6df69b13-2d96-4a69-a297-aedba667e710</GUID>
-        <version>16</version>
+        <version>17</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">260</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_red.xml.fdm_material
+++ b/ultimaker_cpe_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>00181d6c-7024-479a-8eb7-8a2e38a2619a</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#c8102e</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_transparent.xml.fdm_material
+++ b/ultimaker_cpe_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>bd0d9eb3-a920-4632-84e8-dcd6086746c5</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_white.xml.fdm_material
+++ b/ultimaker_cpe_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>881c888e-24fb-4a64-a4ac-d5c95b096cd7</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_cpe_yellow.xml.fdm_material
+++ b/ultimaker_cpe_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>b9176a2a-7a0f-4821-9f29-76d882a88682</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#f6b600</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">240</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">70</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">245</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">10</setting>
         <setting key="break temperature">140</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>c64c2dbe-5691-4363-a7d9-66b2dc12837f</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#27292b</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -40,6 +40,7 @@
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -40,7 +40,7 @@
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -40,7 +40,7 @@
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">245</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">10</setting>
         <setting key="break temperature">140</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>e256615d-a04e-4f53-b311-114b90560af9</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#d0d0d0</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -40,6 +40,7 @@
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -40,7 +40,7 @@
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -40,7 +40,7 @@
         <setting key="retraction speed">25</setting>
         <setting key="adhesion tendency">2</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_pc_black.xml.fdm_material
+++ b/ultimaker_pc_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>e92b1f0b-a069-4969-86b4-30127cfb6f7b</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#0e0e10</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">270</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pc_transparent.xml.fdm_material
+++ b/ultimaker_pc_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>8a38a3e9-ecf7-4a7d-a6a9-e7ac35102968</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#d0d0d0</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">270</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5e786b05-a620-4a87-92d0-f02becc1ff98</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#ecece7</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">270</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_black.xml.fdm_material
+++ b/ultimaker_pla_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>3ee70a86-77d8-4b87-8005-e4a1bc57d2ce</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#0e0e10</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_blue.xml.fdm_material
+++ b/ultimaker_pla_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>44a029e6-e31b-4c9e-a12f-9282e29a92ff</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#00387b</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_green.xml.fdm_material
+++ b/ultimaker_pla_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>2433b8fb-dcd6-4e36-9cd5-9f4ee551c04c</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#61993b</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_magenta.xml.fdm_material
+++ b/ultimaker_pla_magenta.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Magenta</color>
         </name>
         <GUID>fe3982c8-58f4-4d86-9ac0-9ff7a3ab9cbc</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#bc4077</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_orange.xml.fdm_material
+++ b/ultimaker_pla_orange.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>d9549dba-b9df-45b9-80a5-f7140a9a2f34</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#ed6b21</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_pearl-white.xml.fdm_material
+++ b/ultimaker_pla_pearl-white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Pearl-White</color>
         </name>
         <GUID>d9fc79db-82c3-41b5-8c99-33b3747b8fb3</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#e3d9c6</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_red.xml.fdm_material
+++ b/ultimaker_pla_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>9cfe5bf1-bdc5-4beb-871a-52c70777842d</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#bb1e10</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_silver-metallic.xml.fdm_material
+++ b/ultimaker_pla_silver-metallic.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Silver Metallic</color>
         </name>
         <GUID>0e01be8c-e425-4fb1-b4a3-b79f255f1db9</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#a1a1a0</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_transparent.xml.fdm_material
+++ b/ultimaker_pla_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>532e8b3d-5fd4-4149-b936-53ada9bd6b85</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#d0d0d0</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_white.xml.fdm_material
+++ b/ultimaker_pla_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>e509f649-9fe6-4b14-ac45-d441438cb4ef</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#f1ece1</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pla_yellow.xml.fdm_material
+++ b/ultimaker_pla_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>9c1959d0-f597-46ec-9131-34020c7a54fc</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#f9a800</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pp_transparent.xml.fdm_material
+++ b/ultimaker_pp_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>c7005925-2a41-4280-8cdd-4029e3fe5253</GUID>
-        <version>17</version>
+        <version>18</version>
         <color_code>#d0d0d0</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">40</setting>
-        <setting key="break preparation position">-8</setting>
+        <setting key="break preparation retracted position">8</setting>
         <setting key="break preparation speed">17<!--?--></setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">17</setting>
         <setting key="break temperature">100</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -46,12 +46,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retracted position">8</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">215</setting>
-        <setting key="break position">-20</setting>
+        <setting key="break retracted position">20</setting>
         <setting key="break speed">10</setting>
         <setting key="break temperature">130</setting>
         <setting key="maximum park duration">60<!--?--></setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -62,7 +62,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Natural</color>
         </name>
         <GUID>fe15ed8a-33c3-4f57-a2a7-b4b78a38c3cb</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -62,6 +62,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -62,7 +62,7 @@
         <setting key="end of filament purge length">20<!--?--></setting>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/ultimaker_tough_pla_black.xml.fdm_material
+++ b/ultimaker_tough_pla_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>03f24266-0291-43c2-a6da-5211892a2699</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#2a292a</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tough_pla_green.xml.fdm_material
+++ b/ultimaker_tough_pla_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>6d71f4ad-29ab-4b50-8f65-22d99af294dd</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#00a95c</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tough_pla_red.xml.fdm_material
+++ b/ultimaker_tough_pla_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>2db25566-9a91-4145-84a5-46c90ed22bdf</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#de4343</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tough_pla_white.xml.fdm_material
+++ b/ultimaker_tough_pla_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>851427a0-0c9a-4d7c-a9a8-5cc92f84af1f</GUID>
-        <version>10</version>
+        <version>11</version>
         <color_code>#ecece7</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retracted position">4</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation retracted position">16</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">200</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">50</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-6.5</setting>
+        <setting key="anti ooze retracted position">6.5</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">190</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>eff40bcf-588d-420d-a3bc-a5ffd8c7f4b3</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#0e0e10</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -38,6 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-6.5</setting>
+        <setting key="anti ooze retracted position">6.5</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">190</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>5f4a826c-7bfe-460f-8650-a9178b180d34</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#00387b</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -38,6 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-6.5</setting>
+        <setting key="anti ooze retracted position">6.5</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">190</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>07a4547f-d21f-41a0-8eee-bc92125221b3</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#a63437</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -38,6 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6a2573e6-c8ee-4c66-8029-3ebb3d5adc5b</GUID>
-        <version>14</version>
+        <version>15</version>
         <color_code>#f1ece1</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -38,6 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">3</setting>
         <setting key="surface energy">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -19,12 +19,12 @@
         <weight>750</weight>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-6.5</setting>
+        <setting key="anti ooze retracted position">6.5</setting>
         <setting key="anti ooze retract speed">25</setting>
-        <setting key="break preparation position">0</setting>
+        <setting key="break preparation retracted position">0</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">220</setting>
-        <setting key="break position">-50</setting>
+        <setting key="break retracted position">50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">190</setting>
         <setting key="maximum park duration">300</setting>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>

--- a/zyyx_pro_flex.xml.fdm_material
+++ b/zyyx_pro_flex.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura">
     <metadata>
         <name>
             <brand>ZYYX</brand>

--- a/zyyx_pro_flex.xml.fdm_material
+++ b/zyyx_pro_flex.xml.fdm_material
@@ -1,26 +1,27 @@
 <?xml version='1.0' encoding='utf-8'?>
 <fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
-  <metadata>
-    <name>
-      <brand>ZYYX</brand>
-      <material>TPU</material>
-      <color>Generic</color>
-      <label>proFlex</label>
-    </name>
-    <adhesion_info>Use with ZYYX standard build plate</adhesion_info>
-    <description>Fast, safe and reliable printing. ZYYX proFlex is ideal for flexible parts or soft grip parts.</description>
-    <version>1</version>
-    <color_code>#c0c0c0</color_code>
-    <GUID>182d2e1d-02cf-4208-b5e7-08607d0af2d8</GUID>
-  </metadata>
-  <properties>
-    <density>1.2</density>
-    <diameter>1.75</diameter>
-  </properties>
-  <settings>
-    <setting key="print temperature">230</setting>
-    <setting key="heated bed temperature">0</setting>
-    <setting key="standby temperature">200</setting>
-    <setting key="print cooling">100</setting>
-  </settings>
+    <metadata>
+        <name>
+            <brand>ZYYX</brand>
+            <material>TPU</material>
+            <color>Generic</color>
+            <label>proFlex</label>
+        </name>
+        <adhesion_info>Use with ZYYX standard build plate</adhesion_info>
+        <description>Fast, safe and reliable printing. ZYYX proFlex is ideal for flexible parts or soft grip parts.</description>
+        <version>2</version>
+        <color_code>#c0c0c0</color_code>
+        <GUID>182d2e1d-02cf-4208-b5e7-08607d0af2d8</GUID>
+    </metadata>
+    <properties>
+        <density>1.2</density>
+        <diameter>1.75</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">230</setting>
+        <setting key="heated bed temperature">0</setting>
+        <setting key="standby temperature">200</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="cura:material_crystallinity">true</setting>
+    </settings>
 </fdmmaterial>

--- a/zyyx_pro_flex.xml.fdm_material
+++ b/zyyx_pro_flex.xml.fdm_material
@@ -22,6 +22,6 @@
         <setting key="heated bed temperature">0</setting>
         <setting key="standby temperature">200</setting>
         <setting key="print cooling">100</setting>
-        <cura:setting key="material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
     </settings>
 </fdmmaterial>

--- a/zyyx_pro_flex.xml.fdm_material
+++ b/zyyx_pro_flex.xml.fdm_material
@@ -22,6 +22,6 @@
         <setting key="heated bed temperature">0</setting>
         <setting key="standby temperature">200</setting>
         <setting key="print cooling">100</setting>
-        <setting key="cura:material_crystallinity">true</setting>
+        <cura:setting key="material_crystallinity">true</setting>
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
These determine whether a material is crystalline, i.e. break when hot, or not, i.e. break when cold. It is necessary for the depriming procedure.

Contributes to issue CURA-6329.