### PR TITLE
Add CreawsomeMod settings ++

### DIFF
--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -79,19 +79,19 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
         </machine>
 
         <machine>
-            <machine_identifier manufacturer="CreawsomeMod" product="creawsome_base" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10spro" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s4" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s5" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10mini" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr20" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr20pro" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender2" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender3" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender4" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender5" />
+            <machine_identifier manufacturer="CreawsomeMod" product="creality_base" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10spro" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s4" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s5" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10mini" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr20" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr20pro" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender2" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender3" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender4" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender5" />
             <setting key="print cooling">0</setting>
             <setting key="standby temperature">200</setting>
             <setting key="retraction speed">45</setting>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
             <color>Generic</color>
         </name>
         <GUID>69386c85-5b6c-421a-bec5-aeb1fb33f060</GUID>
-        <version>6</version>
+        <version>3</version>
         <color_code>#f3a112</color_code>
         <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>
         <adhesion_info>Set your prime speed to a low value (8mm/sec)</adhesion_info>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -56,19 +56,19 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
         </machine>
         
         <machine>
-            <machine_identifier manufacturer="CreawsomeMod" product="creawsome_base" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10spro" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s4" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s5" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10mini" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr20" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr20pro" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender2" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender3" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender4" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender5" />
+            <machine_identifier manufacturer="CreawsomeMod" product="creality_base" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10spro" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s4" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s5" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10mini" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr20" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr20pro" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender2" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender3" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender4" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender5" />
             <setting key="print cooling">50</setting>
             <setting key="standby temperature">200</setting>
             <setting key="retraction speed">45</setting>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -106,19 +106,19 @@ Generic PLA 1.75mm profile. The data in this file may not be correct for your sp
         </machine>
 
         <machine>
-            <machine_identifier manufacturer="CreawsomeMod" product="creawsome_base" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10spro" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s4" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10s5" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr10mini" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr20" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_cr20pro" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender2" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender3" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender4" />
-            <machine_identifier manufacturer="Creality3D" product="creawsome_ender5" />
+            <machine_identifier manufacturer="CreawsomeMod" product="creality_base" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10spro" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s4" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10s5" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr10mini" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr20" />
+            <machine_identifier manufacturer="Creality3D" product="creality_cr20pro" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender2" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender3" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender4" />
+            <machine_identifier manufacturer="Creality3D" product="creality_ender5" />
             <setting key="print cooling">100</setting>
             <setting key="standby temperature">180</setting>
             <setting key="retraction speed">45</setting>


### PR DESCRIPTION
This is an extension of this PR: https://github.com/Ultimaker/fdm_materials/pull/81
This PR depends on this Cura PR: https://github.com/Ultimaker/Cura/pull/5961, which adds the CreawsomeMod to mainline Cura.

It adds settings specific to Creality printers to these 3 materials. The difference with @trouch 's original PR is that this one has the printer definitions renamed because of the changes I made in the Cura PR.

Contributes to issue CURA-6554.