### PR TITLE
Fix the case that Cura can't slice print jobs with breakaway

### DIFF
--- a/generic_bam.xml.fdm_material
+++ b/generic_bam.xml.fdm_material
@@ -10,7 +10,7 @@ Generic break away support material profile. The data in this file may not be co
             <color>Generic</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d6a0</GUID>
-        <version>15</version>
+        <version>16</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -26,7 +26,7 @@ Generic break away support material profile. The data in this file may not be co
         <setting key="break preparation speed">25</setting>
         <setting key="break preparation temperature">225</setting>
         <setting key="break retracted position">50</setting>
-        <setting key="break speed">85</setting>
+        <setting key="break speed">25</setting>
         <setting key="break temperature">90</setting>
         <setting key="maximum park duration">300</setting>
         <setting key="no load move factor">1.0</setting>

--- a/ultimaker_bam.xml.fdm_material
+++ b/ultimaker_bam.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d5f9</GUID>
-        <version>18</version>
+        <version>19</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -25,7 +25,7 @@
         <setting key="break preparation speed">25</setting>
         <setting key="break preparation temperature">225</setting>
         <setting key="break retracted position">50</setting>
-        <setting key="break speed">85</setting>
+        <setting key="break speed">25</setting>
         <setting key="break temperature">90</setting>
         <setting key="maximum park duration">300</setting>
         <setting key="no load move factor">1.0</setting>


### PR DESCRIPTION
Change the break speed to 25

As indicated by the Materials & Processing team.

Contributes to CURA-6661.