### PR TITLE
Restore 70 degree build plate for AnyCubic 4Max

### DIFF
--- a/imade3d_petg_175.xml.fdm_material
+++ b/imade3d_petg_175.xml.fdm_material
@@ -35,7 +35,6 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
                 <cura:setting key="cool_fan_speed_min">30</cura:setting>
             </hotend>
         </machine>
-        
         <machine>
             <machine_identifier manufacturer="IMADE3D" product="IMADE3D JellyBOX 2"/>
             <hotend id="0.4 mm">
@@ -47,6 +46,10 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
                 <cura:setting key="cool_fan_speed_min">30</cura:setting>
             </hotend>
         </machine>
-        
+
+        <machine>
+            <machine_identifier manufacturer="AnyCubic" product="AnyCubic 4max" />
+            <setting key="heated bed temperature">70</setting>
+        </machine>
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
Previously it would put this in the quality profiles but then you can't override the temperature in the material profile.

Found during investigation of Ultimaker/Cura#6898.