### PR TITLE
Change package name from fdm_materials to fdm-materials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(fdm_materials NONE)
+project(fdm-materials NONE)
 
 cmake_minimum_required(VERSION 2.8.12)
 
@@ -16,7 +16,7 @@ else()
     set(INSTALL_PATH "share/fdm_materials"
         CACHE STRING
         "Destination to install the materials to. Should be relative to CMAKE_INSTALL_PREFIX")
-    
+
     if(IS_ABSOLUTE ${INSTALL_PATH})
         set(INSTALL_PATH ${INSTALL_PATH})
     else()


### PR DESCRIPTION
I think this fix the package name issue, but I don't know how you guys are used to generate the package. I tried locally and seems to work. Please test with your current workflow.

The debian package name should now be: `fdm-materials-<version>-Linux.deb`
If you run the command: `dpkg-deb -I fdm-materials-<version>-Linux.deb`
you should have an output with following line: `Package: fdm-materials`