### PR TITLE
Change shrinkage percentage overrides to Cura-specific settings

### DIFF
--- a/generic_abs.xml.fdm_material
+++ b/generic_abs.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic ABS profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>
@@ -10,7 +10,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>60636bb4-518f-42e7-8237-fe77b194ebe0</GUID>
-        <version>22</version>
+        <version>23</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,7 +39,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#3633F2</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -39,7 +39,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/generic_pc.xml.fdm_material
+++ b/generic_pc.xml.fdm_material
@@ -2,7 +2,7 @@
 <!--
 Generic PC profile. The data in this file may not be correct for your specific machine.
 -->
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Generic</brand>
@@ -10,7 +10,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
             <color>Generic</color>
         </name>
         <GUID>98c05714-bf4e-4455-ba27-57d74fe331e4</GUID>
-        <version>23</version>
+        <version>24</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -39,7 +39,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.7</setting>
+        <cura:setting key="material_shrinkage_percentage">100.7</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
             <color>Generic</color>
         </name>
         <GUID>aa22e9c7-421f-4745-afc2-81851694394a</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#85f9de</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -39,7 +39,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="standby temperature">185</setting>
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>
-        <setting key="shrinkage percentage">102.5</setting>
+        <cura:setting key="material_shrinkage_percentage">102.5</cura:setting>
         <cura:setting key="material_crystallinity">true</cura:setting>
         <setting key="build volume temperature">41</setting>
 

--- a/ultimaker_abs_black.xml.fdm_material
+++ b/ultimaker_abs_black.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>2f9d2279-9b0e-4765-bf9b-d1e1e13f3c49</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#2a292a</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_blue.xml.fdm_material
+++ b/ultimaker_abs_blue.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>7c9575a6-c8d6-40ec-b3dd-18d7956bfaae</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#00387b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_green.xml.fdm_material
+++ b/ultimaker_abs_green.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>3400c0d1-a4e3-47de-a444-7b704f287171</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#61993b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,6 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_grey.xml.fdm_material
+++ b/ultimaker_abs_grey.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Grey</color>
         </name>
         <GUID>8b75b775-d3f2-4d0f-8fb2-2a3dd53cf673</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#52595d</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_orange.xml.fdm_material
+++ b/ultimaker_abs_orange.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>0b4ca6ef-eac8-4b23-b3ca-5f21af00e54f</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#ed6b21</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_pearl-gold.xml.fdm_material
+++ b/ultimaker_abs_pearl-gold.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Pearl Gold</color>
         </name>
         <GUID>7cbdb9ca-081a-456f-a6ba-f73e4e9cb856</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#80643f</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_red.xml.fdm_material
+++ b/ultimaker_abs_red.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>5df7afa6-48bd-4c19-b314-839fe9f08f1f</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#bb1e10</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_silver-metallic.xml.fdm_material
+++ b/ultimaker_abs_silver-metallic.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Silver Metallic</color>
         </name>
         <GUID>763c926e-a5f7-4ba0-927d-b4e038ea2735</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#a1a1a0</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_white.xml.fdm_material
+++ b/ultimaker_abs_white.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5253a75a-27dc-4043-910f-753ae11bc417</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#ecece7</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_abs_yellow.xml.fdm_material
+++ b/ultimaker_abs_yellow.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>e873341d-d9b8-45f9-9a6f-5609e1bcff68</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#f7b500</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">200</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">70</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">36</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_cpe_plus_black.xml.fdm_material
+++ b/ultimaker_cpe_plus_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>1aca047a-42df-497c-abfb-0e9cb85ead52</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#0e0e10</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_cpe_plus_transparent.xml.fdm_material
+++ b/ultimaker_cpe_plus_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>a9c340fe-255f-4914-87f5-ec4fcb0c11ef</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_cpe_plus_white.xml.fdm_material
+++ b/ultimaker_cpe_plus_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6df69b13-2d96-4a69-a297-aedba667e710</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.9</setting>
+        <cura:setting key="material_shrinkage_percentage">100.9</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_pc_black.xml.fdm_material
+++ b/ultimaker_pc_black.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>e92b1f0b-a069-4969-86b4-30127cfb6f7b</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#0e0e10</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.7</setting>
+        <cura:setting key="material_shrinkage_percentage">100.7</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_pc_transparent.xml.fdm_material
+++ b/ultimaker_pc_transparent.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>8a38a3e9-ecf7-4a7d-a6a9-e7ac35102968</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#d0d0d0</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.7</setting>
+        <cura:setting key="material_shrinkage_percentage">100.7</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5e786b05-a620-4a87-92d0-f02becc1ff98</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#ecece7</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">175</setting>
         <setting key="adhesion tendency">0</setting>
         <setting key="surface energy">65</setting>
-        <setting key="shrinkage percentage">100.7</setting>
+        <cura:setting key="material_shrinkage_percentage">100.7</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->

--- a/ultimaker_pp_transparent.xml.fdm_material
+++ b/ultimaker_pp_transparent.xml.fdm_material
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
     <metadata>
         <name>
             <brand>Ultimaker</brand>
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>c7005925-2a41-4280-8cdd-4029e3fe5253</GUID>
-        <version>26</version>
+        <version>27</version>
         <color_code>#d0d0d0</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -38,7 +38,7 @@
         <setting key="standby temperature">185</setting>
         <setting key="print cooling">20</setting>
         <setting key="retraction speed">35</setting>
-        <setting key="shrinkage percentage">102.5</setting>
+        <cura:setting key="material_shrinkage_percentage">102.5</cura:setting>
         <setting key="build volume temperature">41</setting>
 
         <!-- For material flow sensor -->


### PR DESCRIPTION
It turns out that the Ultimaker firmware was not actually using this setting, but it was validating it to be between 0 and 100%, basically validating that a material shouldn't shrink to less than 50% of its original size. When we changed the unit of this setting, this caused their firmware to no longer read these materials.
This change makes this use the Cura namespace and the Cura setting name, so the firmware doesn't recognise the setting any more.

Contributes to issue CURA-7724.