### PR TITLE
Set generic PETG density to 1.27

### DIFF
--- a/generic_petg.xml.fdm_material
+++ b/generic_petg.xml.fdm_material
@@ -16,7 +16,7 @@ Generic PETG profile. The data in this file may not be correct for your specific
         <adhesion_info>Set your prime speed to a low value (8mm/sec)</adhesion_info>
     </metadata>
     <properties>
-        <density>1.38</density>
+        <density>1.27</density>
         <diameter>2.85</diameter>
     </properties>
     <settings>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -16,7 +16,7 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
         <adhesion_info>Set your prime speed to a low value (8mm/sec)</adhesion_info>
     </metadata>
     <properties>
-        <density>1.38</density>
+        <density>1.27</density>
         <diameter>1.75</diameter>
     </properties>
     <settings>


### PR DESCRIPTION
The most commonly sold PETG type have density 1270 kg/m³
The pure PET has density 1.38, but PETG that often used in 3d printing has lower densities (1.24-1.27).
It make more sense to have in Generic PETG profile setting that applies to most of sold materials.

Sources:
- https://en.wikipedia.org/wiki/3D_printing_filament#Materials
- https://www.simplify3d.com/support/materials-guide/properties-table/
- https://shop.prusa3d.com/fotky/PETG_TechSheet_ENG.pdf
- https://github.com/prusa3d/PrusaSlicer/blob/master/resources/profiles/Creality.ini#L246
- https://github.com/prusa3d/PrusaSlicer/blob/master/resources/profiles/PrusaResearch.ini#L1880


