### PR TITLE
Addition of eMotionTech materials and Strateo3D nozzles sizes

### DIFF
--- a/emotiontech_abs.xml.fdm_material
+++ b/emotiontech_abs.xml.fdm_material
@@ -41,12 +41,12 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>

--- a/emotiontech_abs.xml.fdm_material
+++ b/emotiontech_abs.xml.fdm_material
@@ -41,18 +41,16 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_absx.xml.fdm_material
+++ b/emotiontech_absx.xml.fdm_material
@@ -41,12 +41,12 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>

--- a/emotiontech_absx.xml.fdm_material
+++ b/emotiontech_absx.xml.fdm_material
@@ -41,18 +41,16 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_acetate.xml.fdm_material
+++ b/emotiontech_acetate.xml.fdm_material
@@ -40,12 +40,12 @@
                 <setting key="print temperature">235</setting>
                 <setting key="retraction amount">2.3</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">no</setting>
                 <setting key="print temperature">240</setting>
                 <setting key="retraction amount">2.5</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">no</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">2.7</setting>

--- a/emotiontech_acetate.xml.fdm_material
+++ b/emotiontech_acetate.xml.fdm_material
@@ -40,18 +40,16 @@
                 <setting key="print temperature">235</setting>
                 <setting key="retraction amount">2.3</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">no</setting>
                 <setting key="print temperature">240</setting>
                 <setting key="retraction amount">2.5</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">no</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">2.7</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_asax.xml.fdm_material
+++ b/emotiontech_asax.xml.fdm_material
@@ -40,6 +40,16 @@
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+            <hotend id="Standard 1.0 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">250</setting>
+                <setting key="retraction amount">1.6</setting>
+            </hotend>
+            <hotend id="Standard 1.2 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">255</setting>
+                <setting key="retraction amount">1.7</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_asax.xml.fdm_material
+++ b/emotiontech_asax.xml.fdm_material
@@ -40,12 +40,12 @@
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.7</setting>

--- a/emotiontech_bvoh.xml.fdm_material
+++ b/emotiontech_bvoh.xml.fdm_material
@@ -39,18 +39,16 @@
                 <setting key="print temperature">205</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">210</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">213</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_bvoh.xml.fdm_material
+++ b/emotiontech_bvoh.xml.fdm_material
@@ -39,12 +39,12 @@
                 <setting key="print temperature">205</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">210</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">213</setting>
                 <setting key="retraction amount">1.5</setting>

--- a/emotiontech_copa.xml.fdm_material
+++ b/emotiontech_copa.xml.fdm_material
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>eMotionTech</brand>
+            <material>Nylon</material>
+            <color>Generic</color>
+			<label>COPA</label>
+        </name>
+        <GUID>4e16865d-d7a4-4958-95b8-a31533c0785d</GUID>
+        <version>14</version>
+        <color_code>#69E2D5</color_code>
+        <description> </description>
+        <adhesion_info>We recommend the use of PVA glue applied on a cold glass bed before heating</adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.12</density>
+        <diameter>1.75</diameter>
+        <weight>2300</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">45</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="retraction amount">3</setting>
+        <setting key="build volume temperature">45</setting>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <hotend id="Standard 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">250</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+            <hotend id="Standard 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">250</setting>
+                <setting key="retraction amount">3</setting>
+            </hotend>
+            <hotend id="Standard 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">250</setting>
+                <setting key="retraction amount">3</setting>
+            </hotend>
+            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
+            <hotend id="Standard 1.0">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
+            <hotend id="Standard 1.2">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+                <setting key="retraction amount">1.9</setting>
+            </hotend>
+            -->
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/emotiontech_hips.xml.fdm_material
+++ b/emotiontech_hips.xml.fdm_material
@@ -39,18 +39,16 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_hips.xml.fdm_material
+++ b/emotiontech_hips.xml.fdm_material
@@ -39,12 +39,12 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>

--- a/emotiontech_nylon_1030.xml.fdm_material
+++ b/emotiontech_nylon_1030.xml.fdm_material
@@ -41,12 +41,12 @@
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">2.1</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">2.2</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">2.3</setting>

--- a/emotiontech_nylon_1030.xml.fdm_material
+++ b/emotiontech_nylon_1030.xml.fdm_material
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>eMotionTech</brand>
+            <material>Nylon</material>
+            <color>Generic</color>
+            <label>Nylon 1030</label>
+        </name>
+        <GUID>cb7cbe23-bb0b-4d54-95e0-340aaac4541f</GUID>
+        <version>14</version>
+        <color_code>#27292b</color_code>
+        <description> </description>
+        <adhesion_info> </adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.12</density>
+        <diameter>1.75</diameter>
+        <weight>1000</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">250</setting>
+        <setting key="heated bed temperature">100</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="retraction amount">2</setting>
+        <setting key="build volume temperature">35</setting>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <hotend id="Standard 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">240</setting>
+                <setting key="retraction amount">1.9</setting>
+            </hotend>
+            <hotend id="Standard 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+                <setting key="retraction amount">2.0</setting>
+            </hotend>
+            <hotend id="Standard 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">250</setting>
+                <setting key="retraction amount">2.1</setting>
+            </hotend>
+            <hotend id="Standard 1.0 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">255</setting>
+                <setting key="retraction amount">2.2</setting>
+            </hotend>
+            <hotend id="Standard 1.2 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">260</setting>
+                <setting key="retraction amount">2.3</setting>
+            </hotend>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/emotiontech_nylon_1030cf.xml.fdm_material
+++ b/emotiontech_nylon_1030cf.xml.fdm_material
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>eMotionTech</brand>
+            <material>Nylon</material>
+            <color>Generic</color>
+            <label>Nylon 1030CF</label>
+        </name>
+        <GUID>744e712a-d4b7-4617-9a5d-9e7221c3a295</GUID>
+        <version>14</version>
+        <color_code>#27292b</color_code>
+        <description> </description>
+        <adhesion_info> </adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.12</density>
+        <diameter>1.75</diameter>
+        <weight>1000</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">265</setting>
+        <setting key="heated bed temperature">100</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="retraction amount">1.5</setting>
+        <setting key="build volume temperature">35</setting>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <hotend id="Standard 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">255</setting>
+                <setting key="retraction amount">1.4</setting>
+            </hotend>
+            <hotend id="Standard 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">260</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
+            <hotend id="Standard 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">265</setting>
+                <setting key="retraction amount">1.6</setting>
+            </hotend>
+            <hotend id="Standard 1.0 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">270</setting>
+                <setting key="retraction amount">1.7</setting>
+            </hotend>
+            <hotend id="Standard 1.2 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">275</setting>
+                <setting key="retraction amount">1.8</setting>
+            </hotend>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/emotiontech_nylon_1030cf.xml.fdm_material
+++ b/emotiontech_nylon_1030cf.xml.fdm_material
@@ -41,12 +41,12 @@
                 <setting key="print temperature">265</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">270</setting>
                 <setting key="retraction amount">1.7</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">275</setting>
                 <setting key="retraction amount">1.8</setting>

--- a/emotiontech_nylon_1070.xml.fdm_material
+++ b/emotiontech_nylon_1070.xml.fdm_material
@@ -41,12 +41,12 @@
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">2.3</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">265</setting>
                 <setting key="retraction amount">2.7</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">270</setting>
                 <setting key="retraction amount">2.7</setting>

--- a/emotiontech_nylon_1070.xml.fdm_material
+++ b/emotiontech_nylon_1070.xml.fdm_material
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>eMotionTech</brand>
+            <material>Nylon</material>
+            <color>Generic</color>
+            <label>Nylon 1070</label>
+        </name>
+        <GUID>e8ec7612-b626-4861-af93-56549c209bad</GUID>
+        <version>14</version>
+        <color_code>#27292b</color_code>
+        <description> </description>
+        <adhesion_info> </adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.12</density>
+        <diameter>1.75</diameter>
+        <weight>1000</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">260</setting>
+        <setting key="heated bed temperature">100</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="retraction amount">2</setting>
+        <setting key="build volume temperature">35</setting>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <hotend id="Standard 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">250</setting>
+                <setting key="retraction amount">2.1</setting>
+            </hotend>
+            <hotend id="Standard 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">255</setting>
+                <setting key="retraction amount">2.3</setting>
+            </hotend>
+            <hotend id="Standard 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">260</setting>
+                <setting key="retraction amount">2.3</setting>
+            </hotend>
+            <hotend id="Standard 1.0 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">265</setting>
+                <setting key="retraction amount">2.7</setting>
+            </hotend>
+            <hotend id="Standard 1.2 BETA!">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">270</setting>
+                <setting key="retraction amount">2.7</setting>
+            </hotend>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/emotiontech_pc.xml.fdm_material
+++ b/emotiontech_pc.xml.fdm_material
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>eMotionTech</brand>
+            <material>PC</material>
+            <color>Generic</color>
+			<label>PC</label>
+        </name>
+        <GUID>1b29dbfd-0193-427d-a126-a4f8069fbad1</GUID>
+        <version>14</version>
+        <color_code>#DBFAF9</color_code>
+        <description> </description>
+        <adhesion_info>We recommend using a brim for 0.4mm nozzles, but it is not necessary for bigger nozzles</adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.2</density>
+        <diameter>1.75</diameter>
+        <weight>2300</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">280</setting>
+        <setting key="heated bed temperature">120</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="retraction amount">2</setting>
+        <setting key="build volume temperature">60</setting>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <hotend id="Standard 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">270</setting>
+                <setting key="retraction amount">3</setting>
+            </hotend>
+            <hotend id="Standard 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">270</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+            <hotend id="Standard 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">280</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
+            <hotend id="Standard 1.0">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="retraction amount">1.5</setting>
+            </hotend>
+            <hotend id="Standard 1.2">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+                <setting key="retraction amount">1.9</setting>
+            </hotend>
+            -->
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/emotiontech_petg.xml.fdm_material
+++ b/emotiontech_petg.xml.fdm_material
@@ -40,12 +40,12 @@
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">2.0</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">2.0</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">2.3</setting>

--- a/emotiontech_petg.xml.fdm_material
+++ b/emotiontech_petg.xml.fdm_material
@@ -40,18 +40,16 @@
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">2.0</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">2.0</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">2.3</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_pla.xml.fdm_material
+++ b/emotiontech_pla.xml.fdm_material
@@ -40,12 +40,12 @@
                 <setting key="print temperature">215</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">225</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.9</setting>

--- a/emotiontech_pla.xml.fdm_material
+++ b/emotiontech_pla.xml.fdm_material
@@ -40,18 +40,16 @@
                 <setting key="print temperature">215</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">225</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.9</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_pla_hr_870.xml.fdm_material
+++ b/emotiontech_pla_hr_870.xml.fdm_material
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>eMotionTech</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+			<label>PLA HR 870</label>
+        </name>
+        <GUID>92b26c1f-da90-4d69-a35e-d6108727b7cf</GUID>
+        <version>14</version>
+        <color_code>#B28C05</color_code>
+        <description> </description>
+        <adhesion_info>We recommend the use of 3DLac on the glass surface</adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+        <weight>2300</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">220</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="retraction amount">1.4</setting>
+        <setting key="build volume temperature">0</setting>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <hotend id="Standard 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">210</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+            <hotend id="Standard 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">210</setting>
+                <setting key="retraction amount">1.4</setting>
+            </hotend>
+            <hotend id="Standard 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">220</setting>
+                <setting key="retraction amount">1.4</setting>
+            </hotend>
+            <!-- <hotend id="Standard 1.0"> -->
+                <!-- <setting key="hardware compatible">yes</setting> -->
+                <!-- <setting key="print temperature">225</setting> -->
+                <!-- <setting key="retraction amount">1.5</setting> -->
+            <!-- </hotend> -->
+            <!-- <hotend id="Standard 1.2"> -->
+                <!-- <setting key="hardware compatible">yes</setting> -->
+                <!-- <setting key="print temperature">245</setting> -->
+                <!-- <setting key="retraction amount">1.9</setting> -->
+            <!-- </hotend> -->
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/emotiontech_pva-m.xml.fdm_material
+++ b/emotiontech_pva-m.xml.fdm_material
@@ -39,12 +39,12 @@
                 <setting key="print temperature">213</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">215</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">217</setting>
                 <setting key="retraction amount">1.3</setting>

--- a/emotiontech_pva-m.xml.fdm_material
+++ b/emotiontech_pva-m.xml.fdm_material
@@ -39,18 +39,16 @@
                 <setting key="print temperature">213</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">215</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">217</setting>
                 <setting key="retraction amount">1.3</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_pva-s.xml.fdm_material
+++ b/emotiontech_pva-s.xml.fdm_material
@@ -39,18 +39,16 @@
                 <setting key="print temperature">240</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_pva-s.xml.fdm_material
+++ b/emotiontech_pva-s.xml.fdm_material
@@ -39,12 +39,12 @@
                 <setting key="print temperature">240</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">250</setting>
                 <setting key="retraction amount">1.6</setting>

--- a/emotiontech_tpu98a.xml.fdm_material
+++ b/emotiontech_tpu98a.xml.fdm_material
@@ -41,18 +41,16 @@
                 <setting key="print temperature">230</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
-            <hotend id="Standard 1.0">
+            <hotend id="Standard 1.0 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">235</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.2">
+            <hotend id="Standard 1.2 BETA!">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">237</setting>
                 <setting key="retraction amount">1.6</setting>
             </hotend>
-            -->
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_tpu98a.xml.fdm_material
+++ b/emotiontech_tpu98a.xml.fdm_material
@@ -41,12 +41,12 @@
                 <setting key="print temperature">230</setting>
                 <setting key="retraction amount">1.4</setting>
             </hotend>
-            <hotend id="Standard 1.0 BETA!">
+            <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">235</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
-            <hotend id="Standard 1.2 BETA!">
+            <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">237</setting>
                 <setting key="retraction amount">1.6</setting>


### PR DESCRIPTION
-Addition of new materials for 0.4mm, 0.6mm and 0.8mm nozzles
-Update of existing materials to allow 1.0mm and 1.2mm nozzles