### PR TITLE
MISP-1466_Update generic profiles for new deprime

### DIFF
--- a/generic_abs.xml.fdm_material
+++ b/generic_abs.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>60636bb4-518f-42e7-8237-fe77b194ebe0</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -20,20 +20,26 @@ Generic ABS profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
+        <!-- Deprime settings -->
         <setting key="anti ooze retract position">-4</setting>
-        <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
-        <setting key="break preparation speed">10</setting>
+        <setting key="anti ooze retract speed">3</setting>
+        <setting key="break preparation position">-12</setting>
+        <setting key="break preparation speed">50</setting>
         <setting key="break preparation temperature">230</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">85</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.95</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">230</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="standby temperature">200</setting>

--- a/generic_bam.xml.fdm_material
+++ b/generic_bam.xml.fdm_material
@@ -10,7 +10,7 @@ Generic break away support material profile. The data in this file may not be co
             <color>Generic</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d6a0</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -20,20 +20,26 @@ Generic break away support material profile. The data in this file may not be co
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-20</setting>
-        <setting key="anti ooze retract speed">10</setting>
-        <setting key="break preparation position">-10</setting>
-        <setting key="break preparation speed">1</setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-12</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-12</setting>
+        <setting key="break preparation speed">50</setting>
         <setting key="break preparation temperature">230</setting>
         <setting key="break position">-50</setting>
-        <setting key="break speed">25</setting>
+        <setting key="break speed">50</setting>
         <setting key="break temperature">95</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.945</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">100</setting>

--- a/generic_cpe.xml.fdm_material
+++ b/generic_cpe.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>12f41353-1a33-415e-8b4f-a775a6c70cc6</GUID>
-        <version>27</version>
+        <version>28</version>
         <color_code>#159499</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -20,20 +20,26 @@ Generic CPE profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
-        <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-20</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-20</setting>
         <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">250</setting>
         <setting key="break position">-50</setting>
-        <setting key="break speed">25</setting>
+        <setting key="break speed">50</setting>
         <setting key="break temperature">75</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.95</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
-        <version>26</version>
+        <version>27</version>
         <color_code>#3633F2</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -20,20 +20,26 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
-        <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
-        <setting key="break preparation speed">2</setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-6</setting>
+        <setting key="anti ooze retract speed">1</setting>
+        <setting key="break preparation position">-14</setting>
+        <setting key="break preparation speed">35</setting>
         <setting key="break preparation temperature">260</setting>
         <setting key="break position">-50</setting>
-        <setting key="break speed">25</setting>
+        <setting key="break speed">50</setting>
         <setting key="break temperature">105</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.94</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">260</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <color>Generic</color>
         </name>
         <GUID>28fb4162-db74-49e1-9008-d05f1e8bef5c</GUID>
-        <version>23</version>
+        <version>24</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -20,6 +20,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <diameter>2.85</diameter>
     </properties>
     <settings>
+        <!-- Deprime settings -->
         <setting key="anti ooze retract position">-8</setting>
         <setting key="anti ooze retract speed">25</setting>
         <setting key="break preparation position">0</setting>
@@ -28,12 +29,17 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="break position">-50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">145</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.935</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.91</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">245</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_pc.xml.fdm_material
+++ b/generic_pc.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
             <color>Generic</color>
         </name>
         <GUID>98c05714-bf4e-4455-ba27-57d74fe331e4</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -20,20 +20,26 @@ Generic PC profile. The data in this file may not be correct for your specific m
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
-        <setting key="anti ooze retract speed">5</setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-7</setting>
+        <setting key="anti ooze retract speed">50</setting>
         <setting key="break preparation position">-16</setting>
-        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation speed">50</setting>
         <setting key="break preparation temperature">275</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">25</setting>
-        <setting key="break temperature">105</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.94</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="break temperature">95</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">2</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">270</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_petg.xml.fdm_material
+++ b/generic_petg.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PETG profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>1cbfaeb3-1906-4b26-b2e7-6f777a8c197a</GUID>
-        <version>12</version>
+        <version>13</version>
         <color_code>#ff5086</color_code>
         <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -20,20 +20,26 @@ Generic PETG profile. The data in this file may not be correct for your specific
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-4</setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">0</setting>
         <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
-        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation position">0</setting>
+        <setting key="break preparation speed">2</setting>
         <setting key="break preparation temperature">245</setting>
         <setting key="break position">-50</setting>
-        <setting key="break speed">25</setting>
-        <setting key="break temperature">75</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.95</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="break speed">50</setting>
+        <setting key="break temperature">215</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.93</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">240</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PLA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>506c9f0d-e3aa-4bd4-b2d2-23e2425b1aa9</GUID>
-        <version>23</version>
+        <version>24</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -20,20 +20,26 @@ Generic PLA profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
+        <!-- Deprime settings -->
         <setting key="anti ooze retract position">-4</setting>
-        <setting key="anti ooze retract speed">5</setting>
+        <setting key="anti ooze retract speed">50</setting>
         <setting key="break preparation position">-16</setting>
-        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation speed">50</setting>
         <setting key="break preparation temperature">210</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">60</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.94</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.91</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">200</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PLA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>506c9f0d-e3aa-4bd4-b2d2-23e2425b1aa9</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
             <color>Generic</color>
         </name>
         <GUID>aa22e9c7-421f-4745-afc2-81851694394a</GUID>
-        <version>26</version>
+        <version>27</version>
         <color_code>#85f9de</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -20,20 +20,26 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <density>0.89</density>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-8</setting>
-        <setting key="anti ooze retract speed">40</setting>
-        <setting key="break preparation position">-8</setting>
-        <setting key="break preparation speed">17<!--?--></setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-16</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation speed">50</setting>
         <setting key="break preparation temperature">220</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">105</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">1.01</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">1.00</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">220</setting>
         <setting key="heated bed temperature">100</setting>
         <setting key="standby temperature">185</setting>

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>86a89ceb-4159-47f6-ab97-e9953803d70f</GUID>
-        <version>24</version>
+        <version>25</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -20,6 +20,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <diameter>2.85</diameter>
     </properties>
     <settings>
+        <!-- Deprime settings -->
         <setting key="anti ooze retract position">-2</setting>
         <setting key="anti ooze retract speed">20</setting>
         <setting key="break preparation position">-2</setting>
@@ -28,12 +29,17 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="break position">-50</setting>
         <setting key="break speed">50</setting>
         <setting key="break temperature">170</setting>
-        <setting key="maximum park duration">216000</setting>
-        <setting key="no load move factor">0.94</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">216000</setting>
+        <setting key="no load move factor">0.91</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">215</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_tough_pla.xml.fdm_material
+++ b/generic_tough_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>9d5d2d7c-4e77-441c-85a0-e9eefd4aa68c</GUID>
-        <version>18</version>
+        <version>19</version>
         <color_code>#ffc9f0</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -20,20 +20,26 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
         <diameter>2.85</diameter>
     </properties>
     <settings>
+        <!-- Deprime settings -->
         <setting key="anti ooze retract position">-4</setting>
-        <setting key="anti ooze retract speed">5</setting>
-        <setting key="break preparation position">-16</setting>
-        <setting key="break preparation speed">2</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-14</setting>
+        <setting key="break preparation speed">50</setting>
         <setting key="break preparation temperature">230</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">60</setting>
-        <setting key="maximum park duration">7200</setting>
-        <setting key="no load move factor">0.935</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
         <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.93</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">225</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">175</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -10,7 +10,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
             <color>Generic</color>
         </name>
         <GUID>1d52b2be-a3a2-41de-a8b1-3bcdb5618695</GUID>
-        <version>26</version>
+        <version>27</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -20,7 +20,8 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <diameter>2.85</diameter>
     </properties>
     <settings>
-        <setting key="anti ooze retract position">-6.5</setting>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">0</setting>
         <setting key="anti ooze retract speed">25</setting>
         <setting key="break preparation position">0</setting>
         <setting key="break preparation speed">2</setting>
@@ -28,12 +29,17 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="break position">-100</setting>
         <setting key="break speed">25</setting>
         <setting key="break temperature">195</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting> 
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
         <setting key="maximum park duration">7200</setting>
         <setting key="no load move factor">1.03</setting>
-        <setting key="flush purge speed">0.5</setting>
-        <setting key="end of filament purge speed">0.5</setting>
-        <setting key="flush purge length">60</setting>
-        <setting key="end of filament purge length">20</setting>
+
+        <!-- print settings -->
         <setting key="print temperature">228</setting>
         <setting key="heated bed temperature">0</setting>
         <setting key="standby temperature">175</setting>
@@ -41,7 +47,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="surface energy">100</setting>
         <cura:setting key="material_crystallinity">true</cura:setting>
         <setting key="build volume temperature">27</setting>
-
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>


### PR DESCRIPTION
Please note that only generic profiles that have an equivalent ultimaker profile are updated. Other generic profiles still have the old deprime.