### PR TITLE
Removes Cartesio compatibility from Ultimaker materials

### DIFF
--- a/ultimaker_pc_black.xml.fdm_material
+++ b/ultimaker_pc_black.xml.fdm_material
@@ -152,26 +152,5 @@
                 <setting key="hardware recommended">yes</setting>
             </buildplate>
         </machine>
-
-        <machine>
-           <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
-           <setting key="print cooling">0.0</setting>
-           <setting key="standby temperature">160</setting>
-           <setting key="retraction speed">40</setting>
-           <setting key="heated bed temperature">135</setting>
-           <setting key="print temperature">245</setting>
-           <hotend id="0.25mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.0</setting>
-           </hotend>
-           <hotend id="0.4mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.0</setting>
-           </hotend>
-           <hotend id="0.8mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.5</setting>
-           </hotend>
-       </machine>
     </settings>
 </fdmmaterial>

--- a/ultimaker_pc_transparent.xml.fdm_material
+++ b/ultimaker_pc_transparent.xml.fdm_material
@@ -152,26 +152,5 @@
                 <setting key="hardware recommended">yes</setting>
             </buildplate>
         </machine>
-
-        <machine>
-           <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
-           <setting key="print cooling">0.0</setting>
-           <setting key="standby temperature">160</setting>
-           <setting key="retraction speed">40</setting>
-           <setting key="heated bed temperature">135</setting>
-           <setting key="print temperature">245</setting>
-           <hotend id="0.25mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.0</setting>
-           </hotend>
-           <hotend id="0.4mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.0</setting>
-           </hotend>
-           <hotend id="0.8mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.5</setting>
-           </hotend>
-        </machine>
     </settings>
 </fdmmaterial>

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -152,26 +152,5 @@
                 <setting key="hardware recommended">yes</setting>
             </buildplate>
         </machine>
-
-        <machine>
-           <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
-           <setting key="print cooling">0.0</setting>
-           <setting key="standby temperature">160</setting>
-           <setting key="retraction speed">40</setting>
-           <setting key="heated bed temperature">135</setting>
-           <setting key="print temperature">245</setting>
-           <hotend id="0.25mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.0</setting>
-           </hotend>
-           <hotend id="0.4mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.0</setting>
-           </hotend>
-           <hotend id="0.8mm thermoplastic extruder">
-               <setting key="hardware compatible">yes</setting>
-               <setting key="retraction amount">1.5</setting>
-           </hotend>
-        </machine>
     </settings>
 </fdmmaterial>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -163,26 +163,5 @@
                 <setting key="hardware recommended">no</setting>
             </buildplate>
         </machine>
-
-        <machine>
-            <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
-            <setting key="print cooling">0.0</setting>
-            <setting key="standby temperature">160</setting>
-            <setting key="retraction speed">40</setting>
-            <setting key="heated bed temperature">50</setting>
-            <setting key="print temperature">205</setting>
-            <hotend id="0.25mm thermoplastic extruder">
-                <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">1.0</setting>
-            </hotend>
-            <hotend id="0.4mm thermoplastic extruder">
-                <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">1.0</setting>
-            </hotend>
-            <hotend id="0.8mm thermoplastic extruder">
-                <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">1.5</setting>
-            </hotend>
-        </machine>
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
These lines were (accidentally) copied over from the generic materials, but lead to issues in our Material Marketplace.