### PR TITLE
Tronxy Update 2022

### DIFF
--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -60,17 +60,15 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
         <machine>
             <machine_identifier manufacturer="Tronxy" product="tronxy_x" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa" />
-            <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_pro" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_400" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_500" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_d01" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy2" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy2pro" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy3" />
+            <machine_identifier manufacturer="Tronxy" product="tronxy_xy3proV2" />
             <setting key="print cooling">0</setting>
             <setting key="standby temperature">200</setting>
-            <setting key="retraction speed">35</setting>
-            <setting key="retraction amount">5</setting>
             <setting key="print temperature">230</setting>
             <setting key="heated bed temperature">80</setting>
         </machine>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -68,17 +68,15 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
         <machine>
             <machine_identifier manufacturer="Tronxy" product="tronxy_x" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa" />
-            <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_pro" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_400" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_500" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_d01" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy2" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy2pro" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy3" />
-            <setting key="print cooling">75</setting>
+            <machine_identifier manufacturer="Tronxy" product="tronxy_xy3proV2" />
+            <setting key="print cooling">50</setting>
             <setting key="standby temperature">200</setting>
-            <setting key="retraction speed">35</setting>
-            <setting key="retraction amount">5</setting>
             <setting key="print temperature">230</setting>
             <setting key="heated bed temperature">80</setting>
         </machine>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -108,18 +108,15 @@ Generic PLA 1.75mm profile. The data in this file may not be correct for your sp
         <machine>
             <machine_identifier manufacturer="Tronxy" product="tronxy_x" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa" />
-            <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_pro" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_400" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_x5sa_500" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_d01" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy2" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy2pro" />
             <machine_identifier manufacturer="Tronxy" product="tronxy_xy3" />
-
-            <setting key="print cooling">75</setting>
+            <machine_identifier manufacturer="Tronxy" product="tronxy_xy3proV2" />
+            <setting key="print cooling">100</setting>
             <setting key="standby temperature">180</setting>
-            <setting key="retraction speed">40</setting>
-            <setting key="retraction amount">5</setting>
             <setting key="print temperature">200</setting>
             <setting key="heated bed temperature">55</setting>
         </machine>


### PR DESCRIPTION
Removed machine identifier "Tronxy_X5SA_Pro" as it is no longer an active profile in Cura (was removed in the 2020 update PR)
Removed retraction speeds and distance values in order to move them under each individual printer, as bowden lengths and feed styles vary. Also to avoid conflicts between the FDM profiles and printer profiles.

An update of Tronxy machine profiles is currently being worked on and these changes should be made concurrently. 