### PR TITLE
increase retract distance of ABS

### DIFF
--- a/generic_abs.xml.fdm_material
+++ b/generic_abs.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>60636bb4-518f-42e7-8237-fe77b194ebe0</GUID>
-        <version>25</version>
+        <version>26</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -115,13 +115,11 @@ Generic ABS profile. The data in this file may not be correct for your specific 
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -140,17 +138,14 @@ Generic ABS profile. The data in this file may not be correct for your specific 
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_black.xml.fdm_material
+++ b/ultimaker_abs_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>2f9d2279-9b0e-4765-bf9b-d1e1e13f3c49</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#2a292a</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_blue.xml.fdm_material
+++ b/ultimaker_abs_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>7c9575a6-c8d6-40ec-b3dd-18d7956bfaae</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#00387b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_green.xml.fdm_material
+++ b/ultimaker_abs_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>3400c0d1-a4e3-47de-a444-7b704f287171</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#61993b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_grey.xml.fdm_material
+++ b/ultimaker_abs_grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Grey</color>
         </name>
         <GUID>8b75b775-d3f2-4d0f-8fb2-2a3dd53cf673</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#52595d</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_orange.xml.fdm_material
+++ b/ultimaker_abs_orange.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>0b4ca6ef-eac8-4b23-b3ca-5f21af00e54f</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#ed6b21</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_pearl-gold.xml.fdm_material
+++ b/ultimaker_abs_pearl-gold.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Pearl Gold</color>
         </name>
         <GUID>7cbdb9ca-081a-456f-a6ba-f73e4e9cb856</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#80643f</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_red.xml.fdm_material
+++ b/ultimaker_abs_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>5df7afa6-48bd-4c19-b314-839fe9f08f1f</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#bb1e10</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_silver-metallic.xml.fdm_material
+++ b/ultimaker_abs_silver-metallic.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Silver Metallic</color>
         </name>
         <GUID>763c926e-a5f7-4ba0-927d-b4e038ea2735</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#a1a1a0</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_white.xml.fdm_material
+++ b/ultimaker_abs_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5253a75a-27dc-4043-910f-753ae11bc417</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#ecece7</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>

--- a/ultimaker_abs_yellow.xml.fdm_material
+++ b/ultimaker_abs_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>e873341d-d9b8-45f9-9a6f-5609e1bcff68</GUID>
-        <version>28</version>
+        <version>29</version>
         <color_code>#f7b500</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -114,13 +114,11 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
@@ -139,17 +137,14 @@
                 <setting key="print temperature">225</setting>
                 <setting key="standby temperature">85</setting>
                 <setting key="print cooling">40</setting>
-                <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print cooling">2</setting>
                 <setting key="standby temperature">85</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <hotend id="AA 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="retraction amount">5</setting>
             </hotend>
             <buildplate id="Glass">
                 <setting key="hardware compatible">no</setting>


### PR DESCRIPTION
ABS is stringy because of the short retract (5mm). With the updated retract speeds (PP-96) we can safely increase the retract length to the default of 6.5mm. PP-101