### PR TITLE
Polymaker Polyflex material correction/update

### DIFF
--- a/eSUN_PLA_PRO_Black.xml.fdm_material
+++ b/eSUN_PLA_PRO_Black.xml.fdm_material
@@ -3,8 +3,9 @@
     <metadata>
         <name>
             <brand>eSUN</brand>
-            <material>PLA+</material>
+            <material>PLA</material>
             <color>Black</color>
+            <label>Black PLA+</label>
         </name>
         <color_code>#333333</color_code>
         <GUID>5c4e29a1-0722-4cfa-b147-338924afc075</GUID>

--- a/eSUN_PLA_PRO_Grey.xml.fdm_material
+++ b/eSUN_PLA_PRO_Grey.xml.fdm_material
@@ -3,8 +3,9 @@
     <metadata>
         <name>
             <brand>eSUN</brand>
-            <material>PLA+</material>
+            <material>PLA</material>
             <color>Grey</color>
+            <label>Gray PLA+</label>
         </name>
         <color_code>#999999</color_code>
         <GUID>061cc7c6-77b1-4d76-996f-d049546b41d2</GUID>

--- a/eSUN_PLA_PRO_Purple.xml.fdm_material
+++ b/eSUN_PLA_PRO_Purple.xml.fdm_material
@@ -3,8 +3,9 @@
     <metadata>
         <name>
             <brand>eSUN</brand>
-            <material>PLA+</material>
+            <material>PLA</material>
             <color>Purple</color>
+            <label>Purple PLA+</label>
         </name>
         <color_code>#9900CC</color_code>
         <GUID>ae0c8895-b4b3-4a12-a5a5-3ae754940ced</GUID>

--- a/eSUN_PLA_PRO_White.xml.fdm_material
+++ b/eSUN_PLA_PRO_White.xml.fdm_material
@@ -3,8 +3,9 @@
     <metadata>
         <name>
             <brand>eSUN</brand>
-            <material>PLA+</material>
+            <material>PLA</material>
             <color>White</color>
+            <label>White PLA+</label>
         </name>
         <color_code>#EEEEEE</color_code>
         <GUID>832e163d-db99-4a58-80b9-f82073ae0a9b</GUID>

--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -6,8 +6,9 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
     <metadata>
         <name>
             <brand>Generic</brand>
-            <material>CPE+</material>
+            <material>CPE</material>
             <color>Generic</color>
+            <label>CPE+</label>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
         <version>27</version>

--- a/polyflex_tpu.xml.fdm_material
+++ b/polyflex_tpu.xml.fdm_material
@@ -4,7 +4,7 @@
         <name>
             <brand>Polymaker</brand>
             <label>PolyFlex</label>
-            <material>PLA</material>
+            <material>TPU</material>
             <color>Generic</color>
         </name>
         <GUID>88924e7b-a124-418f-a9b5-9fa56dbc47a3</GUID>


### PR DESCRIPTION
Polymaker still makes the PolyFlex materials, however they are not a PLA based material, they are TPU.
Please see the following link to their site.

https://us.polymaker.com/search?type=product&options%5Bprefix%5D=last&options%5Bunavailable_products%5D=last&q=polyflex