### PR TITLE
make PP use a brim per material by default

### DIFF
--- a/ultimaker_pp_transparent.xml.fdm_material
+++ b/ultimaker_pp_transparent.xml.fdm_material
@@ -46,6 +46,7 @@
         <setting key="retraction speed">35</setting>
         <cura:setting key="material_shrinkage_percentage">100</cura:setting>
         <setting key="build volume temperature">41</setting>
+        <cura:setting key="skirt_brim_extruder_nr">-1</cura:setting>
 
         <!-- For material flow sensor -->
         <setting key="relative extrusion">1.0</setting>


### PR DESCRIPTION
Because a PP brim doesn't adhere to any other material, and the other material brim doesn't adhere to the PP part.

Requires https://github.com/Ultimaker/CuraEngine/pull/1613 to be merged first.