### PR TITLE
Minor fix on Label for Eryone TPU Profile

### DIFF
--- a/eryone_tpu.xml.fdm_material
+++ b/eryone_tpu.xml.fdm_material
@@ -5,7 +5,7 @@
       <brand>Eryone</brand>
       <material>TPU</material>
       <color>Generic</color>
-      <label>TPU DD</label>
+      <label>TPU</label>
     </name>
     <version>8</version>
     <GUID>ff52b30e-5740-4f70-a7b5-8c436fc9954f</GUID>


### PR DESCRIPTION
Forgot to change the label to not have DD in the name as this profile support Bowden and DirectDrive setup for the material