### PR TITLE
Disable `travel_avoid_supports` setting for PVA extruders

### DIFF
--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -44,6 +44,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">175</setting>
         <cura:setting key="material_crystallinity">true</cura:setting>
+        <cura:setting key="travel_avoid_supports">False</cura:setting>
         <setting key="build volume temperature">35</setting>
 
         <!-- For material flow sensor -->

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -23,7 +23,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">175</setting>
         <cura:setting key="material_crystallinity">true</cura:setting>
-
+        <cura:setting key="travel_avoid_supports">False</cura:setting>
         <machine>
             <machine_identifier manufacturer="Cartesio bv" product="cartesio" />
             <setting key="print cooling">0.0</setting>

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -70,6 +70,7 @@
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">175</setting>
         <cura:setting key="material_crystallinity">true</cura:setting>
+        <cura:setting key="travel_avoid_supports">False</cura:setting>
         <setting key="build volume temperature">35</setting>
 
         <!-- For material flow sensor -->


### PR DESCRIPTION
Also see https://github.com/Ultimaker/CuraEngine/pull/1665.

CURA-9296