### PR TITLE
Adding 4 new generic materials

### DIFF
--- a/generic_bvoh.xml.fdm_material
+++ b/generic_bvoh.xml.fdm_material
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic BVOH profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>BVOH</material>
+            <color>Generic</color>
+        </name>
+        <GUID>2fb4d442-eb4f-4422-ad35-bdb12b7a27a1</GUID>
+        <version>1</version>
+        <color_code>#ffaaff</color_code>
+        <description>This is the baseline profile for the Water soluble support material BVOH. BVOH is a matching support material for PLA, ABS, ASA, PET-G, Nylon, TPU.</description>
+        <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.14</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">220</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="heated bed temperature">65</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="retraction amount">5</setting>
+        <machine>
+           <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dsigma" />
+           <hotend id="0.3mm" />
+           <hotend id="0.4mm" />
+           <hotend id="0.5mm - Hardened Steel" />
+           <hotend id="0.6mm" />
+           <hotend id="0.8mm" />
+           <hotend id="1.0mm" />
+        </machine>
+        <machine>
+           <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dsigmar19" />
+           <hotend id="0.3mm" />
+           <hotend id="0.4mm" />
+           <hotend id="0.5mm - Hardened Steel" />
+           <hotend id="0.6mm" />
+           <hotend id="0.8mm" />
+           <hotend id="1.0mm" />
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw50" />
+            <setting key="support offset">0</setting>
+            <setting key="heated bed temperature">45</setting>
+            <hotend id="0.4mm" />
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm" />
+            <hotend id="Hotend X (0.6mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.8mm" />
+            <hotend id="1.0mm" />
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw27" />
+            <setting key="support offset">0</setting>
+            <setting key="heated bed temperature">45</setting>
+            <hotend id="0.4mm" />
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm" />
+            <hotend id="Hotend X (0.6mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.8mm" />
+            <hotend id="1.0mm" />
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dd25" />
+            <setting key="support offset">0</setting>
+            <setting key="heated bed temperature">45</setting>
+            <hotend id="0.4mm" />
+            <hotend id="0.8mm" />
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/generic_paht-cf15.xml.fdm_material
+++ b/generic_paht-cf15.xml.fdm_material
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PAHT CF15 profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>PAHT CF15</material>
+            <color>Generic</color>
+        </name>
+        <GUID>b0955e24-d5f2-4ed9-8231-29fc332b7df1</GUID>
+        <version>1</version>
+        <color_code>#343537</color_code>
+        <description>This is the baseline profile for polypropylene 30% glass fibre material.</description>
+    </metadata>
+    <properties>
+        <density>1.233</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">95</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="retraction amount">6.5</setting>
+
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw50" />
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend X (0.6mm)" />
+            <hotend id="0.8mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1.0mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw27" />
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend X (0.6mm)" />
+            <hotend id="0.8mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1.0mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/generic_pet-cf15.xml.fdm_material
+++ b/generic_pet-cf15.xml.fdm_material
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PET CF15 profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>PET CF15</material>
+            <color>Generic</color>
+        </name>
+        <GUID>49d19468-4f75-42a9-b958-3631206d8e76</GUID>
+        <version>1</version>
+        <color_code>#343537</color_code>
+        <description>This is the baseline profile for polyethylene terephthalate carbon fiber reinforced material with 15% carbon fiber reinforced.</description>
+    </metadata>
+    <properties>
+        <density>1.233</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">75</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="retraction amount">6.5</setting>
+
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw50" />
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend X (0.6mm)" />
+            <hotend id="0.8mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1.0mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw27" />
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend X (0.6mm)" />
+            <hotend id="0.8mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1.0mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+    </settings>
+</fdmmaterial>

--- a/generic_pp-gf30.xml.fdm_material
+++ b/generic_pp-gf30.xml.fdm_material
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic PP GF30 profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material" version="1.3">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>PP GF30</material>
+            <color>Generic</color>
+        </name>
+        <GUID>f9912f41-0457-4371-b85f-f405cc050262</GUID>
+        <version>1</version>
+        <color_code>#343537</color_code>
+        <description>This is the baseline profile for high temperature polyamide (nylon) material with 15% carbon fiber reinforced.</description>
+    </metadata>
+    <properties>
+        <density>0.94</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <setting key="print temperature">200</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="retraction amount">6.5</setting>
+
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw50" />
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend X (0.6mm)" />
+            <hotend id="0.8mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1.0mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="BCN3D Technologies" product="bcn3dw27" />
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend M (0.4mm)">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="0.6mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="Hotend X (0.6mm)" />
+            <hotend id="0.8mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1.0mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
Adds 4 new generic materials for 2.85mm. Includes BVOH (for which there was a 1.75mm profile), high-temperature nylon with 15% carbon fiber (PAHT CF15), PET with 15% carbon fiber (PET CF15), PP with 30% glass fibers (PP GF30). They are mainly designed for BCN3D printers.