### PR TITLE
eMotionTech - Updating material files

### DIFF
--- a/emotiontech_abs.xml.fdm_material
+++ b/emotiontech_abs.xml.fdm_material
@@ -25,7 +25,7 @@
         <setting key="retraction amount">1.4</setting>
         <setting key="build volume temperature">60</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">240</setting>
@@ -50,6 +50,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>
+            </hotend>
+			<hotend id="High temp 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">240</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+		<machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_absx.xml.fdm_material
+++ b/emotiontech_absx.xml.fdm_material
@@ -25,7 +25,7 @@
         <setting key="retraction amount">1.4</setting>
         <setting key="build volume temperature">60</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">240</setting>
@@ -50,6 +50,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>
+            </hotend>
+			<hotend id="High temp 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">240</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_acetate.xml.fdm_material
+++ b/emotiontech_acetate.xml.fdm_material
@@ -24,7 +24,7 @@
         <setting key="retraction amount">2</setting>
         <setting key="build volume temperature">0</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">225</setting>
@@ -49,6 +49,30 @@
                 <setting key="hardware compatible">no</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">2.7</setting>
+            </hotend>
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">235</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">235</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_asax.xml.fdm_material
+++ b/emotiontech_asax.xml.fdm_material
@@ -24,7 +24,7 @@
         <setting key="retraction amount">1.3</setting>
         <setting key="build volume temperature">60</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">235</setting>
@@ -49,6 +49,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">255</setting>
                 <setting key="retraction amount">1.7</setting>
+            </hotend>
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">235</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_bvoh.xml.fdm_material
+++ b/emotiontech_bvoh.xml.fdm_material
@@ -21,9 +21,10 @@
     <settings>
         <setting key="print temperature">210</setting>
         <setting key="standby temperature">75</setting>
+        <setting key="speed_print">30</setting>
         <setting key="retraction amount">1.3</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">195</setting>
@@ -49,6 +50,31 @@
                 <setting key="print temperature">213</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">195</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
         </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">210</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">210</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">210</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>        
     </settings>
 </fdmmaterial>

--- a/emotiontech_bvoh.xml.fdm_material
+++ b/emotiontech_bvoh.xml.fdm_material
@@ -21,7 +21,6 @@
     <settings>
         <setting key="print temperature">210</setting>
         <setting key="standby temperature">75</setting>
-        <setting key="speed_print">30</setting>
         <setting key="retraction amount">1.3</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>

--- a/emotiontech_copa.xml.fdm_material
+++ b/emotiontech_copa.xml.fdm_material
@@ -22,7 +22,6 @@
         <setting key="print temperature">265</setting>
         <setting key="heated bed temperature">45</setting>
         <setting key="standby temperature">150</setting>
-        <setting key="speed_print">35</setting>
         <setting key="build volume temperature">45</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>

--- a/emotiontech_copa.xml.fdm_material
+++ b/emotiontech_copa.xml.fdm_material
@@ -11,7 +11,7 @@
         <version>14</version>
         <color_code>#69E2D5</color_code>
         <description> </description>
-        <adhesion_info>We recommend the use of PVA glue applied on a cold glass bed before heating</adhesion_info>
+        <adhesion_info>We recommend the use of 3DLAC applied on a cold glass bed before heating</adhesion_info>
     </metadata>
     <properties>
         <density>1.12</density>
@@ -19,40 +19,65 @@
         <weight>2300</weight>
     </properties>
     <settings>
-        <setting key="print temperature">250</setting>
+        <setting key="print temperature">265</setting>
         <setting key="heated bed temperature">45</setting>
         <setting key="standby temperature">150</setting>
-        <setting key="retraction amount">3</setting>
+        <setting key="speed_print">35</setting>
         <setting key="build volume temperature">45</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">250</setting>
+                <setting key="print temperature">265</setting>
                 <setting key="retraction amount">2</setting>
             </hotend>
             <hotend id="Standard 0.6" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">250</setting>
+                <setting key="print temperature">265</setting>
                 <setting key="retraction amount">3</setting>
             </hotend>
             <hotend id="Standard 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">250</setting>
+                <setting key="print temperature">265</setting>
                 <setting key="retraction amount">3</setting>
             </hotend>
             <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
             <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
+                <setting key="print temperature">265</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
             <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">245</setting>
+                <setting key="print temperature">265</setting>
                 <setting key="retraction amount">1.9</setting>
             </hotend>
             -->
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">265</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">265</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">265</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">265</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_hips.xml.fdm_material
+++ b/emotiontech_hips.xml.fdm_material
@@ -23,7 +23,7 @@
         <setting key="standby temperature">100</setting>
         <setting key="retraction amount">1.3</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">240</setting>
@@ -48,6 +48,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">260</setting>
                 <setting key="retraction amount">1.7</setting>
+            </hotend>
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">240</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_nylon_1030.xml.fdm_material
+++ b/emotiontech_nylon_1030.xml.fdm_material
@@ -5,7 +5,7 @@
             <brand>eMotionTech</brand>
             <material>Nylon</material>
             <color>Generic</color>
-            <label>Nylon 1030</label>
+            <label>Nylon 1030 - Deprecated</label>
         </name>
         <GUID>cb7cbe23-bb0b-4d54-95e0-340aaac4541f</GUID>
         <version>14</version>

--- a/emotiontech_nylon_1030cf.xml.fdm_material
+++ b/emotiontech_nylon_1030cf.xml.fdm_material
@@ -5,7 +5,7 @@
             <brand>eMotionTech</brand>
             <material>Nylon</material>
             <color>Generic</color>
-            <label>Nylon 1030CF</label>
+            <label>Nylon 1030CF - Deprecated</label>
         </name>
         <GUID>744e712a-d4b7-4617-9a5d-9e7221c3a295</GUID>
         <version>14</version>

--- a/emotiontech_nylon_1070.xml.fdm_material
+++ b/emotiontech_nylon_1070.xml.fdm_material
@@ -5,7 +5,7 @@
             <brand>eMotionTech</brand>
             <material>Nylon</material>
             <color>Generic</color>
-            <label>Nylon 1070</label>
+            <label>Nylon 1070 - Deprecated</label>
         </name>
         <GUID>e8ec7612-b626-4861-af93-56549c209bad</GUID>
         <version>14</version>

--- a/emotiontech_pa6cf.xml.fdm_material
+++ b/emotiontech_pa6cf.xml.fdm_material
@@ -3,57 +3,60 @@
     <metadata>
         <name>
             <brand>eMotionTech</brand>
-            <material>Soluble</material>
+            <material>Nylon</material>
             <color>Generic</color>
-            <label>PVA-S</label>
+			<label>PA6CF</label>
         </name>
-        <GUID>bc356ea0-1791-479a-9272-40d228d0269a</GUID>
+        <GUID>692a2059-4680-4744-8e21-254fc8cd9dc7</GUID>
         <version>14</version>
-        <color_code>#D5D8DC</color_code>
-        <description>Water Soluble; Good bonding styrene based materials</description>
-        <adhesion_info> </adhesion_info>
+        <color_code>#69E2D5</color_code>
+        <description> </description>
+        <adhesion_info>We recommend the use of 3DLAC applied on a cold glass bed before heating</adhesion_info>
     </metadata>
     <properties>
-        <density>1.19</density>
+        <density>1.17</density>
         <diameter>1.75</diameter>
-        <weight>750</weight>
+        <weight>500</weight>
     </properties>
     <settings>
-        <setting key="print temperature">245</setting>
-        <setting key="standby temperature">100</setting>
-        <setting key="speed_print">30</setting>
-        <setting key="retraction amount">1.3</setting>
+        <setting key="print temperature">285</setting>
+        <setting key="heated bed temperature">45</setting>
+        <setting key="standby temperature">150</setting>
+        <setting key="speed_print">35</setting>
+        <setting key="build volume temperature">45</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
-                <setting key="retraction amount">1.3</setting>
+                <setting key="print temperature">285</setting>
+                <setting key="retraction amount">2</setting>
             </hotend>
             <hotend id="Standard 0.6" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">235</setting>
-                <setting key="retraction amount">1.4</setting>
+                <setting key="print temperature">285</setting>
+                <setting key="retraction amount">3</setting>
             </hotend>
             <hotend id="Standard 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">240</setting>
-                <setting key="retraction amount">1.4</setting>
+                <setting key="print temperature">285</setting>
+                <setting key="retraction amount">3</setting>
             </hotend>
+            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
             <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">245</setting>
+                <setting key="print temperature">225</setting>
                 <setting key="retraction amount">1.5</setting>
             </hotend>
             <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">250</setting>
-                <setting key="retraction amount">1.6</setting>
+                <setting key="print temperature">245</setting>
+                <setting key="retraction amount">1.9</setting>
             </hotend>
+            -->
 			<hotend id="High temp 0.4" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
-                <setting key="retraction amount">1.3</setting>
+                <setting key="print temperature">285</setting>
+                <setting key="retraction amount">2</setting>
             </hotend>
         </machine>
         <machine>
@@ -61,19 +64,17 @@
             <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
             <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
             <hotend id="IDEX420 Laiton 0.4" >
-                <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">245</setting>
+                <setting key="hardware compatible">no</setting>
             </hotend>
             <hotend id="IDEX420 Laiton 0.6" >
-                <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">245</setting>
+                <setting key="hardware compatible">no</setting>
             </hotend>
             <hotend id="IDEX420 Laiton 0.8">
-                <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">245</setting>
+                <setting key="hardware compatible">no</setting>
             </hotend>
             <hotend id="IDEX420 Acier Durci 0.4">
-                <setting key="hardware compatible">no</setting>
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">285</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_pa6cf.xml.fdm_material
+++ b/emotiontech_pa6cf.xml.fdm_material
@@ -22,7 +22,6 @@
         <setting key="print temperature">285</setting>
         <setting key="heated bed temperature">45</setting>
         <setting key="standby temperature">150</setting>
-        <setting key="speed_print">35</setting>
         <setting key="build volume temperature">45</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>

--- a/emotiontech_pa6gf.xml.fdm_material
+++ b/emotiontech_pa6gf.xml.fdm_material
@@ -3,57 +3,60 @@
     <metadata>
         <name>
             <brand>eMotionTech</brand>
-            <material>PETG</material>
+            <material>Nylon</material>
             <color>Generic</color>
+			<label>PA6GF</label>
         </name>
-        <GUID>f4176e46-e0af-4379-9851-3e295b2db713</GUID>
+        <GUID>5b36a712-ac8b-48a0-b2ee-da3f040e580c</GUID>
         <version>14</version>
-        <color_code>#f3a112</color_code>
+        <color_code>#69E2D5</color_code>
         <description> </description>
-        <adhesion_info>We recommend the use of 3DLac on the glass surface</adhesion_info>
+        <adhesion_info>We recommend the use of 3DLAC applied on a cold glass bed before heating</adhesion_info>
     </metadata>
     <properties>
-        <density>1.27</density>
+        <density>1.35</density>
         <diameter>1.75</diameter>
-        <weight>2300</weight>
+        <weight>500</weight>
     </properties>
     <settings>
-        <setting key="print temperature">240</setting>
-        <setting key="heated bed temperature">70</setting>
+        <setting key="print temperature">290</setting>
+        <setting key="heated bed temperature">45</setting>
         <setting key="standby temperature">150</setting>
-        <setting key="retraction amount">1.7</setting>
-        <setting key="build volume temperature">30</setting>
+        <setting key="speed_print">35</setting>
+        <setting key="build volume temperature">45</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/> 
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">240</setting>
-                <setting key="retraction amount">1.9</setting>
+                <setting key="print temperature">290</setting>
+                <setting key="retraction amount">2</setting>
             </hotend>
             <hotend id="Standard 0.6" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">243</setting>
-                <setting key="retraction amount">1.9</setting>
+                <setting key="print temperature">290</setting>
+                <setting key="retraction amount">3</setting>
             </hotend>
             <hotend id="Standard 0.8">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">245</setting>
-                <setting key="retraction amount">2.0</setting>
+                <setting key="print temperature">290</setting>
+                <setting key="retraction amount">3</setting>
             </hotend>
+            <!-- Commented out until eMotionTech adds their hotend profiles to Cura.
             <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">255</setting>
-                <setting key="retraction amount">2.0</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="retraction amount">1.5</setting>
             </hotend>
             <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">260</setting>
-                <setting key="retraction amount">2.3</setting>
+                <setting key="print temperature">245</setting>
+                <setting key="retraction amount">1.9</setting>
             </hotend>
+            -->
 			<hotend id="High temp 0.4" >
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">240</setting>
-                <setting key="retraction amount">1.9</setting>
+                <setting key="print temperature">290</setting>
+                <setting key="retraction amount">2</setting>
             </hotend>
         </machine>
         <machine>
@@ -61,19 +64,17 @@
             <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
             <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
             <hotend id="IDEX420 Laiton 0.4" >
-                <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">240</setting>
+                <setting key="hardware compatible">no</setting>
             </hotend>
             <hotend id="IDEX420 Laiton 0.6" >
-                <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">240</setting>
+                <setting key="hardware compatible">no</setting>
             </hotend>
             <hotend id="IDEX420 Laiton 0.8">
-                <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">240</setting>
+                <setting key="hardware compatible">no</setting>
             </hotend>
             <hotend id="IDEX420 Acier Durci 0.4">
-                <setting key="hardware compatible">no</setting>
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">290</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_pa6gf.xml.fdm_material
+++ b/emotiontech_pa6gf.xml.fdm_material
@@ -22,7 +22,6 @@
         <setting key="print temperature">290</setting>
         <setting key="heated bed temperature">45</setting>
         <setting key="standby temperature">150</setting>
-        <setting key="speed_print">35</setting>
         <setting key="build volume temperature">45</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/> 

--- a/emotiontech_pc.xml.fdm_material
+++ b/emotiontech_pc.xml.fdm_material
@@ -25,7 +25,7 @@
         <setting key="retraction amount">2</setting>
         <setting key="build volume temperature">60</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">270</setting>
@@ -53,6 +53,31 @@
                 <setting key="retraction amount">1.9</setting>
             </hotend>
             -->
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">270</setting>
+                <setting key="retraction amount">3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">280</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">280</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">280</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_pekk.xml.fdm_material
+++ b/emotiontech_pekk.xml.fdm_material
@@ -25,36 +25,43 @@
         <setting key="retraction amount">1.4</setting>
         <setting key="build volume temperature">60</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">no</setting>
-                <setting key="print temperature">360</setting>
-                <setting key="retraction amount">1.3</setting>
             </hotend>
             <hotend id="Standard 0.6" >
                 <setting key="hardware compatible">no</setting>
-                <setting key="print temperature">365</setting>
-                <setting key="retraction amount">1.4</setting>
             </hotend>
             <hotend id="Standard 0.8">
                 <setting key="hardware compatible">no</setting>
-                <setting key="print temperature">370</setting>
-                <setting key="retraction amount">1.5</setting>
             </hotend>
             <hotend id="Standard 1.0 Experimental">
                 <setting key="hardware compatible">no</setting>
-                <setting key="print temperature">375</setting>
-                <setting key="retraction amount">1.6</setting>
             </hotend>
             <hotend id="Standard 1.2 Experimental">
                 <setting key="hardware compatible">no</setting>
-                <setting key="print temperature">380</setting>
-                <setting key="retraction amount">1.7</setting>
             </hotend>
             <hotend id="High temp 0.4">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">360</setting>
                 <setting key="retraction amount">1.5</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_pla.xml.fdm_material
+++ b/emotiontech_pla.xml.fdm_material
@@ -18,13 +18,13 @@
         <weight>2300</weight>
     </properties>
     <settings>
-        <setting key="print temperature">200</setting>
+        <setting key="print temperature">210</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="standby temperature">150</setting>
         <setting key="retraction amount">1.4</setting>
         <setting key="build volume temperature">0</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">205</setting>
@@ -49,6 +49,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">245</setting>
                 <setting key="retraction amount">1.9</setting>
+            </hotend>
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">205</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">205</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">205</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">205</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_pla_hr_870.xml.fdm_material
+++ b/emotiontech_pla_hr_870.xml.fdm_material
@@ -25,7 +25,7 @@
         <setting key="retraction amount">1.4</setting>
         <setting key="build volume temperature">0</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">210</setting>
@@ -50,7 +50,33 @@
                 <!-- <setting key="hardware compatible">yes</setting> -->
                 <!-- <setting key="print temperature">245</setting> -->
                 <!-- <setting key="retraction amount">1.9</setting> -->
-            <!-- </hotend> -->
+            <!-- </hotend>
+			-->
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">210</setting>
+                <setting key="retraction amount">2</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">220</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">220</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">220</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>

--- a/emotiontech_pva-m.xml.fdm_material
+++ b/emotiontech_pva-m.xml.fdm_material
@@ -21,7 +21,6 @@
     <settings>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">75</setting>
-        <setting key="speed_print">30</setting>
         <setting key="retraction amount">1.3</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>

--- a/emotiontech_pva-m.xml.fdm_material
+++ b/emotiontech_pva-m.xml.fdm_material
@@ -21,9 +21,10 @@
     <settings>
         <setting key="print temperature">215</setting>
         <setting key="standby temperature">75</setting>
+        <setting key="speed_print">30</setting>
         <setting key="retraction amount">1.3</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">205</setting>
@@ -48,6 +49,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">217</setting>
                 <setting key="retraction amount">1.3</setting>
+            </hotend>
+			<hotend id="High temp 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">205</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">215</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">215</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">215</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>

--- a/emotiontech_pva-s.xml.fdm_material
+++ b/emotiontech_pva-s.xml.fdm_material
@@ -21,7 +21,6 @@
     <settings>
         <setting key="print temperature">245</setting>
         <setting key="standby temperature">100</setting>
-        <setting key="speed_print">30</setting>
         <setting key="retraction amount">1.3</setting>
         <machine>
             <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>

--- a/emotiontech_tpu98a.xml.fdm_material
+++ b/emotiontech_tpu98a.xml.fdm_material
@@ -25,7 +25,7 @@
         <setting key="retraction amount">1.3</setting>
         <setting key="build volume temperature">0</setting>
         <machine>
-            <machine_identifier manufacturer="eMotionTech" product="Strateo3D"/>
+            <machine_identifier manufacturer="eMotionTech" product="DUAL600"/>
             <hotend id="Standard 0.4" >
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">220</setting>
@@ -50,6 +50,31 @@
                 <setting key="hardware compatible">yes</setting>
                 <setting key="print temperature">237</setting>
                 <setting key="retraction amount">1.6</setting>
+            </hotend>
+			<hotend id="High temp 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">220</setting>
+                <setting key="retraction amount">1.3</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Duplicate"/>
+            <machine_identifier manufacturer="eMotionTech" product="IDEX420 Mirror"/>
+            <hotend id="IDEX420 Laiton 0.4" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">235</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.6" >
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">235</setting>
+            </hotend>
+            <hotend id="IDEX420 Laiton 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">235</setting>
+            </hotend>
+            <hotend id="IDEX420 Acier Durci 0.4">
+                <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
     </settings>


### PR DESCRIPTION
- nylon_1030, nylon_1030CF, nylon_1070 are now "deprecated" (see label in files)
- pa6CF and pa6GF are added to eMotionTech catalogue
- Strateo3D machine is renamed "DUAL600" because Strateo3D is a brand of several machines (DUAL600 and IDEX420)
- Strateo IDEX420 mchine is added to material files