### PR TITLE
Improved model quality with BAM support

### DIFF
--- a/generic_petcf.xml.fdm_material
+++ b/generic_petcf.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PET-CF profile. The data in this file may not be correct for your specif
             <color>Generic</color>
         </name>
         <GUID>64d44410-be10-428c-8891-f0ae47ea1734</GUID>
-        <version>22</version>
+        <version>23</version>
         <color_code>#888888</color_code>
         <description>Generic PET CF profile. The data in this file may not be correct for your specific machine.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -48,7 +48,7 @@ Generic PET-CF profile. The data in this file may not be correct for your specif
         <setting key="build volume temperature">37</setting>
         <setting key="print cooling">10</setting>
         <setting key="retraction amount">10</setting>
-        <setting key="adhesion tendency">2</setting>
+        <setting key="adhesion tendency">1</setting>
         <setting key="surface energy">100</setting>
         <cura:setting key="material_flow">95</cura:setting>
 

--- a/ultimaker_petcf_black.xml.fdm_material
+++ b/ultimaker_petcf_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>a6f8d4f1-7205-40cc-b9e5-3bad20bc8011</GUID>
-        <version>18</version>
+        <version>19</version>
         <color_code>#1e1e1e</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -47,7 +47,7 @@
         <setting key="build volume temperature">37</setting>
         <setting key="print cooling">10</setting>
         <setting key="retraction amount">10</setting>
-        <setting key="adhesion tendency">2</setting>
+        <setting key="adhesion tendency">1</setting>
         <setting key="surface energy">100</setting>
         <cura:setting key="material_flow">95</cura:setting>
 

--- a/ultimaker_petcf_blue.xml.fdm_material
+++ b/ultimaker_petcf_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>81555f45-354b-42e0-bc0d-e0357cb56dd4</GUID>
-        <version>18</version>
+        <version>19</version>
         <color_code>#025669</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -47,7 +47,7 @@
         <setting key="build volume temperature">37</setting>
         <setting key="print cooling">10</setting>
         <setting key="retraction amount">10</setting>
-        <setting key="adhesion tendency">2</setting>
+        <setting key="adhesion tendency">1</setting>
         <setting key="surface energy">100</setting>
         <cura:setting key="material_flow">95</cura:setting>
 

--- a/ultimaker_petcf_gray.xml.fdm_material
+++ b/ultimaker_petcf_gray.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Gray</color>
         </name>
         <GUID>98896281-3972-4dc5-8d6d-76ed417b10ea</GUID>
-        <version>18</version>
+        <version>19</version>
         <color_code>#8d948d</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -47,7 +47,7 @@
         <setting key="build volume temperature">37</setting>
         <setting key="print cooling">10</setting>
         <setting key="retraction amount">10</setting>
-        <setting key="adhesion tendency">2</setting>
+        <setting key="adhesion tendency">1</setting>
         <setting key="surface energy">100</setting>
         <cura:setting key="material_flow">95</cura:setting>
 


### PR DESCRIPTION
Improve model bottom surface quality PET-CF in combination with BAM for the 0.15mm print mode by reducing the z support distance to 1 iso 2 layers.

PP-352