### PR TITLE
PP-350 cleanup print temperature

### DIFF
--- a/generic_abs.xml.fdm_material
+++ b/generic_abs.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>60636bb4-518f-42e7-8237-fe77b194ebe0</GUID>
-        <version>34</version>
+        <version>35</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -40,8 +40,8 @@ Generic ABS profile. The data in this file may not be correct for your specific 
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -55,8 +55,14 @@ Generic ABS profile. The data in this file may not be correct for your specific 
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -69,7 +75,6 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -108,7 +113,6 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -127,7 +131,6 @@ Generic ABS profile. The data in this file may not be correct for your specific 
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/generic_cpe.xml.fdm_material
+++ b/generic_cpe.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>12f41353-1a33-415e-8b4f-a775a6c70cc6</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#159499</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -40,8 +40,8 @@ Generic CPE profile. The data in this file may not be correct for your specific 
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -53,8 +53,14 @@ Generic CPE profile. The data in this file may not be correct for your specific 
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -69,7 +75,6 @@ Generic CPE profile. The data in this file may not be correct for your specific 
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -105,7 +110,6 @@ Generic CPE profile. The data in this file may not be correct for your specific 
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@ Generic CPE profile. The data in this file may not be correct for your specific 
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/generic_cpe_plus.xml.fdm_material
+++ b/generic_cpe_plus.xml.fdm_material
@@ -10,7 +10,7 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>e2409626-b5a0-4025-b73e-b58070219259</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#3633F2</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -40,8 +40,8 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">260</setting>
-        <setting key="standby temperature">160</setting>
+        <setting key="print temperature">270</setting>
+        <setting key="standby temperature">170</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@ Generic CPE+ profile. The data in this file may not be correct for your specific
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">260</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">260</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.4 mm" />

--- a/generic_nylon.xml.fdm_material
+++ b/generic_nylon.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <color>Generic</color>
         </name>
         <GUID>28fb4162-db74-49e1-9008-d05f1e8bef5c</GUID>
-        <version>31</version>
+        <version>32</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -40,8 +40,8 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="no load move factor">0.91</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">245</setting>
-        <setting key="standby temperature">145</setting>
+        <setting key="print temperature">250</setting>
+        <setting key="standby temperature">150</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">35</setting>
         <setting key="retraction amount">8</setting>
@@ -56,8 +56,14 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">245</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">245</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -73,7 +79,6 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -112,7 +117,6 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
                 <setting key="retraction speed">45</setting>
             </hotend>
@@ -135,7 +139,6 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
                 <setting key="retraction speed">45</setting>
             </hotend>

--- a/generic_pc.xml.fdm_material
+++ b/generic_pc.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC profile. The data in this file may not be correct for your specific m
             <color>Generic</color>
         </name>
         <GUID>98c05714-bf4e-4455-ba27-57d74fe331e4</GUID>
-        <version>34</version>
+        <version>35</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -40,8 +40,8 @@ Generic PC profile. The data in this file may not be correct for your specific m
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">270</setting>
-        <setting key="standby temperature">170</setting>
+        <setting key="print temperature">280</setting>
+        <setting key="standby temperature">180</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -53,9 +53,16 @@ Generic PC profile. The data in this file may not be correct for your specific m
         <setting key="relative extrusion">1.0</setting>
         <setting key="flow sensor detection margin">0.8</setting>
         <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">270</setting>
+        </machine>
+
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">270</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />

--- a/generic_petg.xml.fdm_material
+++ b/generic_petg.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PETG profile. The data in this file may not be correct for your specific
             <color>Generic</color>
         </name>
         <GUID>1cbfaeb3-1906-4b26-b2e7-6f777a8c197a</GUID>
-        <version>23</version>
+        <version>24</version>
         <color_code>#ff5086</color_code>
         <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -77,7 +77,6 @@ Generic PETG profile. The data in this file may not be correct for your specific
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -96,7 +95,6 @@ Generic PETG profile. The data in this file may not be correct for your specific
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -121,7 +119,6 @@ Generic PETG profile. The data in this file may not be correct for your specific
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/generic_pla.xml.fdm_material
+++ b/generic_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PLA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>506c9f0d-e3aa-4bd4-b2d2-23e2425b1aa9</GUID>
-        <version>34</version>
+        <version>35</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/generic_pp.xml.fdm_material
+++ b/generic_pp.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
             <color>Generic</color>
         </name>
         <GUID>aa22e9c7-421f-4745-afc2-81851694394a</GUID>
-        <version>41</version>
+        <version>42</version>
         <color_code>#85f9de</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -40,8 +40,8 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="no load move factor">1.00</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">220</setting>
-        <setting key="standby temperature">120</setting>
+        <setting key="print temperature">207</setting>
+        <setting key="standby temperature">107</setting>
         <setting key="heated bed temperature">100</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="print cooling">20</setting>
@@ -56,8 +56,14 @@ Generic Polypropylene profile. Serves as an example file, data in this file is n
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">220</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">220</setting>
 
             <setting key="retraction amount">8</setting>
 

--- a/generic_pva.xml.fdm_material
+++ b/generic_pva.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA profile. The data in this file may not be correct for your specific 
             <color>Generic</color>
         </name>
         <GUID>86a89ceb-4159-47f6-ab97-e9953803d70f</GUID>
-        <version>33</version>
+        <version>34</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -40,8 +40,8 @@ Generic PVA profile. The data in this file may not be correct for your specific 
         <setting key="no load move factor">0.91</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">215</setting>
-        <setting key="standby temperature">115</setting>
+        <setting key="print temperature">220</setting>
+        <setting key="standby temperature">120</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">35</setting>
         <cura:setting key="material_crystallinity">true</cura:setting>

--- a/generic_tough_pla.xml.fdm_material
+++ b/generic_tough_pla.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>9d5d2d7c-4e77-441c-85a0-e9eefd4aa68c</GUID>
-        <version>29</version>
+        <version>30</version>
         <color_code>#ffc9f0</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -40,8 +40,8 @@ Generic Tough PLA profile. The data in this file may not be correct for your spe
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/generic_tpu.xml.fdm_material
+++ b/generic_tpu.xml.fdm_material
@@ -10,7 +10,7 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
             <color>Generic</color>
         </name>
         <GUID>1d52b2be-a3a2-41de-a8b1-3bcdb5618695</GUID>
-        <version>34</version>
+        <version>35</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -40,8 +40,8 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="no load move factor">1.03</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">228</setting>
-        <setting key="standby temperature">128</setting>
+        <setting key="print temperature">225</setting>
+        <setting key="standby temperature">125</setting>
         <setting key="heated bed temperature">0</setting>
         <setting key="build volume temperature">27</setting>
         <setting key="adhesion tendency">3</setting>
@@ -54,8 +54,14 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">228</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">228</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />
@@ -69,7 +75,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -104,7 +109,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -121,8 +125,6 @@ Generic TPU 95A profile. The data in this file may not be correct for your speci
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
-
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/ultimaker_abs_black.xml.fdm_material
+++ b/ultimaker_abs_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>2f9d2279-9b0e-4765-bf9b-d1e1e13f3c49</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#2a292a</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_blue.xml.fdm_material
+++ b/ultimaker_abs_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>7c9575a6-c8d6-40ec-b3dd-18d7956bfaae</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#00387b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_green.xml.fdm_material
+++ b/ultimaker_abs_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>3400c0d1-a4e3-47de-a444-7b704f287171</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#61993b</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_grey.xml.fdm_material
+++ b/ultimaker_abs_grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Gray</color>
         </name>
         <GUID>8b75b775-d3f2-4d0f-8fb2-2a3dd53cf673</GUID>
-        <version>38</version>
+        <version>39</version>
         <color_code>#52595d</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_orange.xml.fdm_material
+++ b/ultimaker_abs_orange.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>0b4ca6ef-eac8-4b23-b3ca-5f21af00e54f</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#ed6b21</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_pearl-gold.xml.fdm_material
+++ b/ultimaker_abs_pearl-gold.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Pearl Gold</color>
         </name>
         <GUID>7cbdb9ca-081a-456f-a6ba-f73e4e9cb856</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#80643f</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_red.xml.fdm_material
+++ b/ultimaker_abs_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>5df7afa6-48bd-4c19-b314-839fe9f08f1f</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#bb1e10</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_silver-metallic.xml.fdm_material
+++ b/ultimaker_abs_silver-metallic.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Silver</color>
         </name>
         <GUID>763c926e-a5f7-4ba0-927d-b4e038ea2735</GUID>
-        <version>38</version>
+        <version>39</version>
         <color_code>#a1a1a0</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_white.xml.fdm_material
+++ b/ultimaker_abs_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5253a75a-27dc-4043-910f-753ae11bc417</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#ecece7</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_abs_yellow.xml.fdm_material
+++ b/ultimaker_abs_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>e873341d-d9b8-45f9-9a6f-5609e1bcff68</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#f7b500</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">230</setting>
-        <setting key="standby temperature">130</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">80</setting>
         <setting key="build volume temperature">36</setting>
         <setting key="adhesion tendency">0</setting>
@@ -54,8 +54,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">230</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">230</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
@@ -107,7 +112,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -126,7 +130,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">225</setting>
                 <setting key="print cooling">40</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_black.xml.fdm_material
+++ b/ultimaker_cpe_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>a8955dc3-9d7e-404d-8c03-0fd6fee7f22d</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#2a292a</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_blue.xml.fdm_material
+++ b/ultimaker_cpe_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>4d816290-ce2e-40e0-8dc8-3f702243131e</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#00a3e0</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_dark-grey.xml.fdm_material
+++ b/ultimaker_cpe_dark-grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Dark Gray</color>
         </name>
         <GUID>10961c00-3caf-48e9-a598-fa805ada1e8d</GUID>
-        <version>41</version>
+        <version>42</version>
         <color_code>#4f5250</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_green.xml.fdm_material
+++ b/ultimaker_cpe_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>7ff6d2c8-d626-48cd-8012-7725fa537cc9</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#78be20</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_light-grey.xml.fdm_material
+++ b/ultimaker_cpe_light-grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Light Gray</color>
         </name>
         <GUID>173a7bae-5e14-470e-817e-08609c61e12b</GUID>
-        <version>41</version>
+        <version>42</version>
         <color_code>#c5c7c4</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_plus_black.xml.fdm_material
+++ b/ultimaker_cpe_plus_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>1aca047a-42df-497c-abfb-0e9cb85ead52</GUID>
-        <version>42</version>
+        <version>43</version>
         <color_code>#0e0e10</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">260</setting>
-        <setting key="standby temperature">160</setting>
+        <setting key="print temperature">270</setting>
+        <setting key="standby temperature">170</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">260</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">260</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.4 mm" />

--- a/ultimaker_cpe_plus_transparent.xml.fdm_material
+++ b/ultimaker_cpe_plus_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>a9c340fe-255f-4914-87f5-ec4fcb0c11ef</GUID>
-        <version>42</version>
+        <version>43</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">260</setting>
-        <setting key="standby temperature">160</setting>
+        <setting key="print temperature">270</setting>
+        <setting key="standby temperature">170</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">260</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">260</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.4 mm" />

--- a/ultimaker_cpe_plus_white.xml.fdm_material
+++ b/ultimaker_cpe_plus_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6df69b13-2d96-4a69-a297-aedba667e710</GUID>
-        <version>42</version>
+        <version>43</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">260</setting>
-        <setting key="standby temperature">160</setting>
+        <setting key="print temperature">270</setting>
+        <setting key="standby temperature">170</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">260</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">260</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.4 mm" />

--- a/ultimaker_cpe_red.xml.fdm_material
+++ b/ultimaker_cpe_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>00181d6c-7024-479a-8eb7-8a2e38a2619a</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#c8102e</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_transparent.xml.fdm_material
+++ b/ultimaker_cpe_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>bd0d9eb3-a920-4632-84e8-dcd6086746c5</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#d0d0d0</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_white.xml.fdm_material
+++ b/ultimaker_cpe_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>881c888e-24fb-4a64-a4ac-d5c95b096cd7</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#f1ece1</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_cpe_yellow.xml.fdm_material
+++ b/ultimaker_cpe_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>b9176a2a-7a0f-4821-9f29-76d882a88682</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#f6b600</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">240</setting>
-        <setting key="standby temperature">140</setting>
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
         <setting key="heated bed temperature">85</setting>
         <setting key="build volume temperature">37</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,8 +52,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">240</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">240</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -68,7 +74,6 @@
             <cura:setting key="retraction_combing">all</cura:setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -104,7 +109,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -125,7 +129,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_nylon_black.xml.fdm_material
+++ b/ultimaker_nylon_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>c64c2dbe-5691-4363-a7d9-66b2dc12837f</GUID>
-        <version>34</version>
+        <version>35</version>
         <color_code>#27292b</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.91</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">245</setting>
-        <setting key="standby temperature">145</setting>
+        <setting key="print temperature">250</setting>
+        <setting key="standby temperature">150</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">35</setting>
         <setting key="retraction amount">8</setting>
@@ -55,8 +55,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">245</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">245</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -72,7 +78,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -111,7 +116,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
                 <setting key="retraction speed">45</setting>
             </hotend>
@@ -134,7 +138,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
                 <setting key="retraction speed">45</setting>
             </hotend>

--- a/ultimaker_nylon_transparent.xml.fdm_material
+++ b/ultimaker_nylon_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>e256615d-a04e-4f53-b311-114b90560af9</GUID>
-        <version>34</version>
+        <version>35</version>
         <color_code>#d0d0d0</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.91</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">245</setting>
-        <setting key="standby temperature">145</setting>
+        <setting key="print temperature">250</setting>
+        <setting key="standby temperature">150</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">35</setting>
         <setting key="retraction amount">8</setting>
@@ -55,8 +55,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">245</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">245</setting>
 
             <hotend id="0.25 mm" />
             <hotend id="0.4 mm" />
@@ -72,7 +78,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -111,7 +116,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
                 <setting key="retraction speed">45</setting>
             </hotend>
@@ -134,7 +138,6 @@
 
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
                 <setting key="retraction speed">45</setting>
             </hotend>

--- a/ultimaker_pc_black.xml.fdm_material
+++ b/ultimaker_pc_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>e92b1f0b-a069-4969-86b4-30127cfb6f7b</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#0e0e10</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">270</setting>
-        <setting key="standby temperature">170</setting>
+        <setting key="print temperature">280</setting>
+        <setting key="standby temperature">180</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,9 +52,16 @@
         <setting key="relative extrusion">1.0</setting>
         <setting key="flow sensor detection margin">0.8</setting>
         <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">270</setting>
+        </machine>
+
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">270</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />

--- a/ultimaker_pc_transparent.xml.fdm_material
+++ b/ultimaker_pc_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>8a38a3e9-ecf7-4a7d-a6a9-e7ac35102968</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#d0d0d0</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">270</setting>
-        <setting key="standby temperature">170</setting>
+        <setting key="print temperature">280</setting>
+        <setting key="standby temperature">180</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,9 +52,16 @@
         <setting key="relative extrusion">1.0</setting>
         <setting key="flow sensor detection margin">0.8</setting>
         <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">270</setting>
+        </machine>
+
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">270</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />

--- a/ultimaker_pc_white.xml.fdm_material
+++ b/ultimaker_pc_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>5e786b05-a620-4a87-92d0-f02becc1ff98</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#ecece7</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.92</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">270</setting>
-        <setting key="standby temperature">170</setting>
+        <setting key="print temperature">280</setting>
+        <setting key="standby temperature">180</setting>
         <setting key="heated bed temperature">107</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="adhesion tendency">0</setting>
@@ -52,9 +52,16 @@
         <setting key="relative extrusion">1.0</setting>
         <setting key="flow sensor detection margin">0.8</setting>
         <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">270</setting>
+        </machine>
+
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">270</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />

--- a/ultimaker_petg_black.xml.fdm_material
+++ b/ultimaker_petg_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>5f9f3de0-045b-48d9-84ec-19db92be7603</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#2a292a</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_blue.xml.fdm_material
+++ b/ultimaker_petg_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>2257ab94-fb27-42e6-865c-05aa6717504b</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#005387</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_blue_translucent.xml.fdm_material
+++ b/ultimaker_petg_blue_translucent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue Translucent</color>
         </name>
         <GUID>e0af2080-29fc-4b18-a5c0-42ca112f507f</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#0033A0</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_green.xml.fdm_material
+++ b/ultimaker_petg_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>c8e4a85e-b256-4468-8516-0aa98c69c7d7</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#008351</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_green_translucent.xml.fdm_material
+++ b/ultimaker_petg_green_translucent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green Translucent</color>
         </name>
         <GUID>1f3c3be1-2e60-4343-b35d-cb383958d992</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#006341</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_grey.xml.fdm_material
+++ b/ultimaker_petg_grey.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Gray</color>
         </name>
         <GUID>c8394116-30ba-4112-b4d9-8b2394278cb3</GUID>
-        <version>41</version>
+        <version>42</version>
         <color_code>#575d5e</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_orange.xml.fdm_material
+++ b/ultimaker_petg_orange.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>a02a3978-eb33-47ca-b32b-d08b92b58638</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#FC4C02</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_red.xml.fdm_material
+++ b/ultimaker_petg_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>9680dff6-7aa5-400b-982c-40a0de06a718</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#bb1e10</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_red_translucent.xml.fdm_material
+++ b/ultimaker_petg_red_translucent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red Translucent</color>
         </name>
         <GUID>c8639119-5cae-4f56-9bcf-3bb00e8225fd</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#93272C</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_silver.xml.fdm_material
+++ b/ultimaker_petg_silver.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Silver</color>
         </name>
         <GUID>40a273c6-0e15-4db5-a278-8eb0b4a9e293</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#a1a1a0</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_transparent.xml.fdm_material
+++ b/ultimaker_petg_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>7418eca4-e2c4-45b1-a022-37180861fd39</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#d0d0d0</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_white.xml.fdm_material
+++ b/ultimaker_petg_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>61eb5c6c-0110-49de-9756-13b8c7cc2ff1</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#ecece7</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_yellow.xml.fdm_material
+++ b/ultimaker_petg_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>218379df-4a67-4668-b5f8-2a14c92bce96</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#f1dd38</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_petg_yellow_fluorescent.xml.fdm_material
+++ b/ultimaker_petg_yellow_fluorescent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow Fluorescent</color>
         </name>
         <GUID>d67a3ccb-6b51-4013-bdac-4c59e952aaf4</GUID>
-        <version>40</version>
+        <version>41</version>
         <color_code>#B1D600</color_code>
         <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -76,7 +76,6 @@
             <setting key="heated bed temperature">85</setting>
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
-                <setting key="print temperature">230</setting>
             </hotend>
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -95,7 +94,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">
@@ -120,7 +118,6 @@
             <hotend id="AA 0.25">
                 <setting key="hardware compatible">yes</setting>
                 <setting key="heated bed temperature">85</setting>
-                <setting key="print temperature">230</setting>
                 <setting key="retraction amount">6.5</setting>
             </hotend>
             <hotend id="AA 0.4">

--- a/ultimaker_pla_black.xml.fdm_material
+++ b/ultimaker_pla_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>3ee70a86-77d8-4b87-8005-e4a1bc57d2ce</GUID>
-        <version>36</version>
+        <version>37</version>
         <color_code>#0e0e10</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_blue.xml.fdm_material
+++ b/ultimaker_pla_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>44a029e6-e31b-4c9e-a12f-9282e29a92ff</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#00387b</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_green.xml.fdm_material
+++ b/ultimaker_pla_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>2433b8fb-dcd6-4e36-9cd5-9f4ee551c04c</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#61993b</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_magenta.xml.fdm_material
+++ b/ultimaker_pla_magenta.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Magenta</color>
         </name>
         <GUID>fe3982c8-58f4-4d86-9ac0-9ff7a3ab9cbc</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#bc4077</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_orange.xml.fdm_material
+++ b/ultimaker_pla_orange.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Orange</color>
         </name>
         <GUID>d9549dba-b9df-45b9-80a5-f7140a9a2f34</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#ed6b21</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_pearl-white.xml.fdm_material
+++ b/ultimaker_pla_pearl-white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Pearl-White</color>
         </name>
         <GUID>d9fc79db-82c3-41b5-8c99-33b3747b8fb3</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#e3d9c6</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_red.xml.fdm_material
+++ b/ultimaker_pla_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>9cfe5bf1-bdc5-4beb-871a-52c70777842d</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#bb1e10</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_silver-metallic.xml.fdm_material
+++ b/ultimaker_pla_silver-metallic.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Silver Metallic</color>
         </name>
         <GUID>0e01be8c-e425-4fb1-b4a3-b79f255f1db9</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#a1a1a0</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_transparent.xml.fdm_material
+++ b/ultimaker_pla_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>532e8b3d-5fd4-4149-b936-53ada9bd6b85</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#d0d0d0</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_white.xml.fdm_material
+++ b/ultimaker_pla_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>e509f649-9fe6-4b14-ac45-d441438cb4ef</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#f1ece1</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pla_yellow.xml.fdm_material
+++ b/ultimaker_pla_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>9c1959d0-f597-46ec-9131-34020c7a54fc</GUID>
-        <version>39</version>
+        <version>40</version>
         <color_code>#f9a800</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>

--- a/ultimaker_pp_transparent.xml.fdm_material
+++ b/ultimaker_pp_transparent.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Transparent</color>
         </name>
         <GUID>c7005925-2a41-4280-8cdd-4029e3fe5253</GUID>
-        <version>44</version>
+        <version>45</version>
         <color_code>#d0d0d0</color_code>
         <description>Fatigue and chemical resistant. Polypropylene offers excellent temperature, chemical and fatigue resistance. Its toughness and low friction make it a perfect choice for prototyping and creating durable end-use models.</description>
         <adhesion_info>Adhesion sheets are required.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">1.00</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">220</setting>
-        <setting key="standby temperature">120</setting>
+        <setting key="print temperature">207</setting>
+        <setting key="standby temperature">107</setting>
         <setting key="heated bed temperature">100</setting>
         <setting key="build volume temperature">41</setting>
         <setting key="print cooling">20</setting>
@@ -55,8 +55,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">220</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">220</setting>
 
             <setting key="retraction amount">8</setting>
 

--- a/ultimaker_pva.xml.fdm_material
+++ b/ultimaker_pva.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Natural</color>
         </name>
         <GUID>fe15ed8a-33c3-4f57-a2a7-b4b78a38c3cb</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -66,8 +66,8 @@
         <setting key="no load move factor">0.91</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">215</setting>
-        <setting key="standby temperature">115</setting>
+        <setting key="print temperature">220</setting>
+        <setting key="standby temperature">120</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">35</setting>
         <cura:setting key="material_crystallinity">true</cura:setting>

--- a/ultimaker_tough_pla_black.xml.fdm_material
+++ b/ultimaker_tough_pla_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>03f24266-0291-43c2-a6da-5211892a2699</GUID>
-        <version>32</version>
+        <version>33</version>
         <color_code>#2a292a</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tough_pla_blue.xml.fdm_material
+++ b/ultimaker_tough_pla_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>4b049931-6ee9-408c-8588-ddd4673467d1</GUID>
-        <version>11</version>
+        <version>12</version>
         <color_code>#1B5583</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tough_pla_gray.xml.fdm_material
+++ b/ultimaker_tough_pla_gray.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Gray</color>
         </name>
         <GUID>6660eb2e-aa40-49ad-ac9b-ada979f3de9b</GUID>
-        <version>11</version>
+        <version>12</version>
         <color_code>#78858B</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tough_pla_green.xml.fdm_material
+++ b/ultimaker_tough_pla_green.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Green</color>
         </name>
         <GUID>6d71f4ad-29ab-4b50-8f65-22d99af294dd</GUID>
-        <version>32</version>
+        <version>33</version>
         <color_code>#00a95c</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tough_pla_red.xml.fdm_material
+++ b/ultimaker_tough_pla_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>2db25566-9a91-4145-84a5-46c90ed22bdf</GUID>
-        <version>32</version>
+        <version>33</version>
         <color_code>#de4343</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tough_pla_white.xml.fdm_material
+++ b/ultimaker_tough_pla_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>851427a0-0c9a-4d7c-a9a8-5cc92f84af1f</GUID>
-        <version>32</version>
+        <version>33</version>
         <color_code>#ecece7</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tough_pla_yellow.xml.fdm_material
+++ b/ultimaker_tough_pla_yellow.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Yellow</color>
         </name>
         <GUID>bfdb0787-032d-4cf5-9975-964132bd641c</GUID>
-        <version>11</version>
+        <version>12</version>
         <color_code>#F8F32B</color_code>
         <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
         <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">0.93</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">225</setting>
-        <setting key="standby temperature">125</setting>
+        <setting key="print temperature">215</setting>
+        <setting key="standby temperature">115</setting>
         <setting key="heated bed temperature">60</setting>
         <setting key="build volume temperature">24</setting>
         <setting key="print cooling">100</setting>

--- a/ultimaker_tpu_black.xml.fdm_material
+++ b/ultimaker_tpu_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>eff40bcf-588d-420d-a3bc-a5ffd8c7f4b3</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#0e0e10</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">1.03</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">228</setting>
-        <setting key="standby temperature">128</setting>
+        <setting key="print temperature">225</setting>
+        <setting key="standby temperature">125</setting>
         <setting key="heated bed temperature">0</setting>
         <setting key="build volume temperature">27</setting>
         <setting key="adhesion tendency">3</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">228</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">228</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />
@@ -68,7 +74,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -103,7 +108,6 @@
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -120,8 +124,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
-
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/ultimaker_tpu_blue.xml.fdm_material
+++ b/ultimaker_tpu_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>5f4a826c-7bfe-460f-8650-a9178b180d34</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#00387b</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">1.03</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">228</setting>
-        <setting key="standby temperature">128</setting>
+        <setting key="print temperature">225</setting>
+        <setting key="standby temperature">125</setting>
         <setting key="heated bed temperature">0</setting>
         <setting key="build volume temperature">27</setting>
         <setting key="adhesion tendency">3</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">228</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">228</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />
@@ -68,7 +74,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -103,7 +108,6 @@
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -120,8 +124,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
-
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/ultimaker_tpu_red.xml.fdm_material
+++ b/ultimaker_tpu_red.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Red</color>
         </name>
         <GUID>07a4547f-d21f-41a0-8eee-bc92125221b3</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#a63437</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">1.03</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">228</setting>
-        <setting key="standby temperature">128</setting>
+        <setting key="print temperature">225</setting>
+        <setting key="standby temperature">125</setting>
         <setting key="heated bed temperature">0</setting>
         <setting key="build volume temperature">27</setting>
         <setting key="adhesion tendency">3</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">228</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">228</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />
@@ -68,7 +74,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -103,7 +108,6 @@
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -120,8 +124,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
-
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/ultimaker_tpu_white.xml.fdm_material
+++ b/ultimaker_tpu_white.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>6a2573e6-c8ee-4c66-8029-3ebb3d5adc5b</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#f1ece1</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -39,8 +39,8 @@
         <setting key="no load move factor">1.03</setting>
 
         <!-- print settings -->
-        <setting key="print temperature">228</setting>
-        <setting key="standby temperature">128</setting>
+        <setting key="print temperature">225</setting>
+        <setting key="standby temperature">125</setting>
         <setting key="heated bed temperature">0</setting>
         <setting key="build volume temperature">27</setting>
         <setting key="adhesion tendency">3</setting>
@@ -53,8 +53,14 @@
         <setting key="retract compensation">0</setting>
 
         <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+            <setting key="print temperature">228</setting>
+        </machine>
+
+        <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="print temperature">228</setting>
             <setting key="hardware compatible">yes</setting>
 
             <hotend id="0.25 mm" />
@@ -68,7 +74,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -103,7 +108,6 @@
 
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>
@@ -120,8 +124,6 @@
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
             <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
-
-            <setting key="print temperature">223</setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>


### PR DESCRIPTION
# Description
Changed the print temperature in the .xml.fdm_material profiles to match the actual print temparature on a 0.4 nozzle @ 0.15mm layers. This to make the temperatures more consistent. There is a matching branch in [Cura](https://github.com/Ultimaker/Cura/tree/PP-350_cleanup_print_temperature) ([PR](https://github.com/Ultimaker/Cura/pull/15943)). These pull requests should be merged simultaneously.

All the relevant quality files have been adjusted to have the correct temperature offset on top of default_material_print_temperature to have the same resulting printing temperature.