### PR TITLE
Add Generic (Any color) material profiles

### DIFF
--- a/scripts/fdmmaterial.xsd
+++ b/scripts/fdmmaterial.xsd
@@ -64,6 +64,7 @@
                             <xsd:element name="MSDS" type="url" minOccurs="0"/>
                             <xsd:element name="supplier" type="contact_info" minOccurs="0"/>
                             <xsd:element name="author" type="contact_info" minOccurs="0"/>
+                            <xsd:element name="abstract_color" type="xsd:boolean" minOccurs="0"/>
                             <!-- Specifically allow any settings from the Cura Namespace to be added here -->
                             <xsd:any minOccurs="0" namespace="http://www.ultimaker.com/cura" processContents ="lax"/>
                         </xsd:choice>

--- a/ultimaker_abs.xml.fdm_material
+++ b/ultimaker_abs.xml.fdm_material
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>ABS</material>
+            <color>Generic</color>
+            <label>Any color ABS</label>
+        </name>
+        <GUID>94209c78-8d4d-4866-8a60-5e1f7adb0c36</GUID>
+        <version>5</version>
+        <color_code>#8cb219</color_code>
+        <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
+        <adhesion_info>Use glue, to avoid chipping of the glass.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-abs/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.1</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retract speed">3</setting>
+        <setting key="break preparation position">-12</setting>
+        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation temperature">230</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">85</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">230</setting>
+        <setting key="standby temperature">130</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">36</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">70</setting>
+        <cura:setting key="cool_fan_speed_max">15</cura:setting>
+        <cura:setting key="material_shrinkage_percentage">100</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="print cooling">40</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">5</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">90</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="heated bed temperature">85</setting>
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.25 mm">
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="0.4 mm">
+                <setting key="print temperature">250</setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">260</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="print temperature">260</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="heated bed temperature">85</setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="print cooling">40</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">2</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+            <setting key="heated bed temperature">85</setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">225</setting>
+                <setting key="print cooling">40</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">2</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe.xml.fdm_material
+++ b/ultimaker_cpe.xml.fdm_material
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE</material>
+            <color>Generic</color>
+            <label>Any color CPE</label>
+        </name>
+        <GUID>3cf87e76-dae0-42cb-ae86-3d39918af2ad</GUID>
+        <version>5</version>
+        <color_code>#159499</color_code>
+        <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
+        <adhesion_info>Use glue.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-cpe/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-20</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-20</setting>
+        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation temperature">250</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">50</setting>
+        <setting key="break temperature">75</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">240</setting>
+        <setting key="standby temperature">140</setting>
+        <setting key="heated bed temperature">85</setting>
+        <setting key="build volume temperature">37</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">70</setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="heated bed temperature">85</setting>
+            <cura:setting key="retraction_combing">all</cura:setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="heated bed temperature">85</setting>
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.25 mm">
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="0.4 mm">
+                <setting key="print temperature">250</setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">260</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="print temperature">260</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="heated bed temperature">85</setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">20</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <setting key="heated bed temperature">85</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="print cooling">20</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="retraction speed">40</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_cpe_plus.xml.fdm_material
+++ b/ultimaker_cpe_plus.xml.fdm_material
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>CPE+</material>
+            <color>Generic</color>
+            <label>Any color CPE+</label>
+        </name>
+        <GUID>4034cfaa-a512-4645-a07d-89a2dd4db91d</GUID>
+        <version>5</version>
+        <color_code>#3633F2</color_code>
+        <description>Chemically resistant and tough. CPE+ is chemically inert, tough, dimensionally stable and handles temperatures up to 100ºC.</description>
+        <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-cpe-plus/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.18</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-6</setting>
+        <setting key="anti ooze retract speed">1</setting>
+        <setting key="break preparation position">-14</setting>
+        <setting key="break preparation speed">35</setting>
+        <setting key="break preparation temperature">260</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">50</setting>
+        <setting key="break temperature">105</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">260</setting>
+        <setting key="standby temperature">160</setting>
+        <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">41</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">65</setting>
+        <cura:setting key="material_shrinkage_percentage">100</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="hardware compatible">yes</setting>
+
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <cura:setting key="retraction_combing">all</cura:setting>
+
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">7</setting>
+                <setting key="print cooling">1</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">8</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="print temperature">260</setting>
+            <setting key="hardware compatible">yes</setting>
+
+            <hotend id="0.4 mm">
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="heated bed temperature">110</setting>
+
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">7</setting>
+                <setting key="print cooling">1</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">8</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+            <setting key="heated bed temperature">110</setting>
+
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="print cooling">1</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="print cooling">8</setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_nylon.xml.fdm_material
+++ b/ultimaker_nylon.xml.fdm_material
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>Nylon</material>
+            <color>Generic</color>
+            <label>Any color Nylon</label>
+        </name>
+        <GUID>c6714ed4-9734-4266-b4e1-d90b8b0c2434</GUID>
+        <version>5</version>
+        <color_code>#3DF266</color_code>
+        <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
+        <adhesion_info>Use glue.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-nylon/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.14</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-8</setting>
+        <setting key="anti ooze retract speed">25</setting>
+        <setting key="break preparation position">0</setting>
+        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation temperature">250</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">145</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.91</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">245</setting>
+        <setting key="standby temperature">145</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">35</setting>
+        <setting key="retraction amount">8</setting>
+        <setting key="retraction speed">25</setting>
+        <setting key="adhesion tendency">2</setting>
+        <setting key="surface energy">100</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="print cooling">40</setting>
+            <setting key="heated bed temperature">40</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.25 mm">
+                <setting key="print temperature">240</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="0.4 mm">
+                <setting key="print temperature">250</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">255</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="print temperature">260</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="print cooling">40</setting>
+            <setting key="heated bed temperature">40</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <setting key="print cooling">40</setting>
+            <setting key="heated bed temperature">40</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="retraction speed">45</setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pc.xml.fdm_material
+++ b/ultimaker_pc.xml.fdm_material
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PC</material>
+            <color>Generic</color>
+            <label>Any color PC</label>
+        </name>
+        <GUID>59675b16-d902-4cb3-a780-a539cae0b04d</GUID>
+        <version>5</version>
+        <color_code>#F29030</color_code>
+        <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
+        <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-pc/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.19</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-7</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation temperature">275</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">95</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">2</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">270</setting>
+        <setting key="standby temperature">170</setting>
+        <setting key="heated bed temperature">107</setting>
+        <setting key="build volume temperature">41</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">65</setting>
+        <cura:setting key="cool_fan_speed_max">15</cura:setting>
+        <cura:setting key="material_shrinkage_percentage">100</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="hardware compatible">yes</setting>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">0</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="retraction speed">35</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">5</setting>
+            </hotend>
+         </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="print temperature">260</setting>
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="heated bed temperature">110</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">0</setting>
+                <setting key="retraction amount">8</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">5</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <setting key="heated bed temperature">110</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">0</setting>
+                <setting key="retraction amount">8</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="print cooling">5</setting>
+            </hotend>
+        </machine>
+
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_petcf.xml.fdm_material
+++ b/ultimaker_petcf.xml.fdm_material
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PET CF</material>
+            <color>Generic</color>
+            <label>Any color PET-CF</label>
+        </name>
+        <GUID>f0245d40-3657-4615-b9ab-19fc043944ca</GUID>
+        <version>5</version>
+        <color_code>#888888</color_code>
+        <description>Ultimaker PET-CF.</description>
+        <adhesion_info>Print on bare glass.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-pet-cf/printing-guidelines</instruction_link>
+        <cura:pva_compatible>True</cura:pva_compatible>
+        <cura:breakaway_compatible>True</cura:breakaway_compatible>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.39</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-16</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation temperature">265</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">50</setting>
+        <setting key="break temperature">265</setting>
+        <setting key="pressure release dwell time">50</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.94</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">270</setting>
+        <setting key="standby temperature">165</setting>
+        <setting key="heated bed temperature">80</setting>
+        <setting key="build volume temperature">37</setting>
+        <setting key="print cooling">10</setting>
+        <setting key="retraction amount">10</setting>
+        <setting key="adhesion tendency">1</setting>
+        <setting key="surface energy">100</setting>
+        <cura:setting key="material_flow">95</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="BB 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="BB 0.8">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="CC 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="CC 0.6">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="BB 0.4">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="BB 0.8">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="CC 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="CC 0.6">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_petg.xml.fdm_material
+++ b/ultimaker_petg.xml.fdm_material
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PETG</material>
+            <color>Generic</color>
+            <label>Any color PETG</label>
+        </name>
+        <GUID>91bd2402-1766-4cb0-9b21-6435e5095395</GUID>
+        <version>5</version>
+        <color_code>#ff5086</color_code>
+        <description>Ultimaker PETG is easily printable and a good all-round material. For anyone needing parts that require more chemical and heat resistance than PLA, this is an excellent material to use.</description>
+        <adhesion_info>Use glue.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-petg/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.27</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">0</setting>
+        <setting key="anti ooze retract speed">5</setting>
+        <setting key="break preparation position">0</setting>
+        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation temperature">245</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">50</setting>
+        <setting key="break temperature">215</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.93</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">240</setting>
+        <setting key="standby temperature">140</setting>
+        <setting key="heated bed temperature">85</setting>
+        <setting key="build volume temperature">37</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">70</setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="heated bed temperature">85</setting>
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.25 mm">
+                <setting key="print temperature">230</setting>
+            </hotend>
+            <hotend id="0.4 mm">
+                <setting key="print temperature">245</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">250</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="print temperature">245</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="heated bed temperature">85</setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print temperature">230</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">20</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <cura:setting key="material_shrinkage_percentage">100.5</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.1</cura:setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">85</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">85</setting>
+                <setting key="print cooling">20</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">85</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <cura:setting key="material_shrinkage_percentage">100.5</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.1</cura:setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">85</setting>
+                <setting key="print temperature">230</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">85</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="print cooling">20</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="heated bed temperature">85</setting>
+                <setting key="retraction amount">8</setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_pla.xml.fdm_material
+++ b/ultimaker_pla.xml.fdm_material
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>PLA</material>
+            <color>Generic</color>
+            <label>Any color PLA</label>
+        </name>
+        <GUID>5b890432-a9f1-45e4-aad7-a73995600276</GUID>
+        <version>5</version>
+        <color_code>#ffc924</color_code>
+        <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>
+        <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-pla/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation temperature">210</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">60</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.91</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">200</setting>
+        <setting key="standby temperature">100</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">28</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">100</setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm" />
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Go"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended"/>
+            <setting key="processing temperature graph">
+                <point flow="2" temperature="180"/>
+                <point flow="10" temperature="230"/>
+            </setting>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Original"/>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="print cooling">100</setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="hardware compatible">yes</setting>
+            <hotend id="0.25 mm">
+                <setting key="print temperature">195</setting>
+            </hotend>
+            <hotend id="0.4 mm">
+                <setting key="print temperature">210</setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">230</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="print temperature">240</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="print cooling">100</setting>
+            <cura:setting key="material_shrinkage_percentage">100.2</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.1</cura:setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+            <hotend id="CC 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="CC 0.6">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <setting key="print cooling">100</setting>
+            <cura:setting key="material_shrinkage_percentage">100.2</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.1</cura:setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+            <hotend id="CC 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+                <cura:setting key="material_crystallinity">true</cura:setting>
+            </hotend>
+            <hotend id="CC 0.6">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+                <cura:setting key="material_crystallinity">true</cura:setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_tough_pla.xml.fdm_material
+++ b/ultimaker_tough_pla.xml.fdm_material
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>Tough PLA</material>
+            <color>Generic</color>
+            <label>Any color Tough PLA</label>
+        </name>
+        <GUID>2c31d5ae-a75c-4be6-83bf-377341fc6d24</GUID>
+        <version>5</version>
+        <color_code>#ffc9f0</color_code>
+        <description>Technical PLA material with toughness similar to ABS. Ideal for reliably printing functional prototypes and tooling at larger sizes, Tough PLA offers the same safe and easy use as regular PLA.</description>
+        <adhesion_info>Print on bare glass. Use tape for cold build plates.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-tough-pla/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retract speed">50</setting>
+        <setting key="break preparation position">-14</setting>
+        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation temperature">230</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">60</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.93</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">225</setting>
+        <setting key="standby temperature">125</setting>
+        <setting key="heated bed temperature">60</setting>
+        <setting key="build volume temperature">24</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">100</setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="print cooling">100</setting>
+
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+
+            <hotend id="0.25 mm">
+                <setting key="print temperature">210</setting>
+            </hotend>
+            <hotend id="0.4 mm">
+                <setting key="print temperature">225</setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">245</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="print temperature">255</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="print cooling">100</setting>
+            <cura:setting key="material_shrinkage_percentage">100.3</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.1</cura:setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <setting key="print cooling">100</setting>
+            <cura:setting key="material_shrinkage_percentage">100.3</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.1</cura:setting>
+            <hotend id="AA 0.25">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">6.5</setting>
+            </hotend>
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">5</setting>
+                <cura:setting key="cool_min_layer_time">10</cura:setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>

--- a/ultimaker_tpu.xml.fdm_material
+++ b/ultimaker_tpu.xml.fdm_material
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>TPU 95A</material>
+            <color>Generic</color>
+            <label>Any color TPU</label>
+        </name>
+        <GUID>bddeb098-9e1f-4d0b-be9f-e99f6f8277d8</GUID>
+        <version>5</version>
+        <color_code>#B22744</color_code>
+        <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
+        <adhesion_info>Use glue.</adhesion_info>
+        <instruction_link>https://ultimaker.com/in/cura/materials/ultimaker-tpu-95a/printing-guidelines</instruction_link>
+        <abstract_color>true</abstract_color>
+    </metadata>
+    <properties>
+        <density>1.22</density>
+        <diameter>2.85</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">0</setting>
+        <setting key="anti ooze retract speed">25</setting>
+        <setting key="break preparation position">0</setting>
+        <setting key="break preparation speed">2</setting>
+        <setting key="break preparation temperature">223</setting>
+        <setting key="break position">-100</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">195</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">0</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">1.03</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">228</setting>
+        <setting key="standby temperature">128</setting>
+        <setting key="heated bed temperature">0</setting>
+        <setting key="build volume temperature">27</setting>
+        <setting key="adhesion tendency">3</setting>
+        <setting key="surface energy">100</setting>
+        <cura:setting key="material_crystallinity">true</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="flow sensor detection margin">0.8</setting>
+        <setting key="retract compensation">0</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2 Extended+"/>
+            <setting key="hardware compatible">yes</setting>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm" />
+            <hotend id="0.6 mm" />
+            <hotend id="0.8 mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 3 Extended"/>
+            <setting key="print temperature">223</setting>
+
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">20</setting>
+                <setting key="retraction speed">35</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction speed">45</setting>
+                <setting key="print cooling">50</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker 2+ Connect"/>
+            <setting key="hardware compatible">yes</setting>
+            <setting key="print temperature">235</setting>
+            <setting key="retraction amount">10</setting>
+
+            <hotend id="0.25 mm" />
+            <hotend id="0.4 mm">
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="0.6 mm">
+                <setting key="print temperature">240</setting>
+            </hotend>
+            <hotend id="0.8 mm">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S3"/>
+            <setting key="print temperature">223</setting>
+
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">20</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction speed">45</setting>
+                <setting key="print cooling">50</setting>
+            </hotend>
+        </machine>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S5"/>
+            <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker S7"/>
+
+            <setting key="print temperature">223</setting>
+
+            <hotend id="AA 0.4">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="print cooling">20</setting>
+                <setting key="retraction amount">8</setting>
+                <cura:setting key="cool_min_layer_time">3</cura:setting>
+            </hotend>
+            <hotend id="AA 0.8">
+                <setting key="hardware compatible">yes</setting>
+                <setting key="retraction amount">8</setting>
+                <setting key="retraction speed">45</setting>
+                <setting key="print cooling">50</setting>
+            </hotend>
+        </machine>
+
+
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
Add Generic (Any color) material profiles. 
First merge: https://github.com/Ultimaker/fdm_materials/pull/262 to allow for the new <abstract_color> tag

PP-245