### PR TITLE
Add prime tower when raft contains support material

### DIFF
--- a/ultimaker_abscf_175.xml.fdm_material
+++ b/ultimaker_abscf_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>495a0ce5-9daf-4a16-b7b2-06856d82394d</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#0e0e10</color_code>
         <description>The performance of carbon fiber with the reliability of ABS</description>
         <adhesion_info>No glue needed</adhesion_info>
@@ -46,6 +46,7 @@
                 <setting key="hardware compatible">yes</setting>
             </hotend>
         </machine>
+
         <machine>
             <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Method XL"/>
             <setting key="build volume temperature">85</setting>
@@ -65,7 +66,7 @@
             <hotend id="1C">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
-            <hotend id="Lab">
+            <hotend id="LABS">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
         </machine>

--- a/ultimaker_absr_175.xml.fdm_material
+++ b/ultimaker_absr_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>88c8919c-6a09-471a-b7b6-e801263d862d</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>No glue needed</adhesion_info>
@@ -42,7 +42,7 @@
             <hotend id="1C">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
-            <hotend id="Lab">
+            <hotend id="LABS">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
         </machine>
@@ -65,7 +65,7 @@
             <hotend id="1C">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
-            <hotend id="Lab">
+            <hotend id="LABS">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
         </machine>

--- a/ultimaker_rapidrinse_175.xml.fdm_material
+++ b/ultimaker_rapidrinse_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>a140ef8f-4f26-4e73-abe0-cfc29d6d1024</GUID>
-        <version>5</version>
+        <version>6</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material for ABS-R.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -28,7 +28,7 @@
 
         <!-- Define as soluble support material -->
         <cura:setting key="material_is_support_material">True</cura:setting>
-        <cura:setting key="prime_tower_enable">=extruder_nr==support_extruder_nr</cura:setting>
+        <cura:setting key="prime_tower_enable">=extruder_nr==support_extruder_nr or extruder_nr==raft_base_extruder_nr or extruder_nr==raft_interface_extruder_nr or extruder_nr==raft_surface_extruder_nr</cura:setting>
         <cura:setting key="support_conical_enabled">True</cura:setting>
 
         <machine>
@@ -49,10 +49,9 @@
             <hotend id="1C">
                 <setting key="hardware compatible">no</setting>
             </hotend>
-            <hotend id="Lab">
+            <hotend id="LABS">
                 <setting key="hardware compatible">no</setting>
             </hotend>
         </machine>
-
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
- Add prime tower when raft uses Method support materials (even when self support is enabled).
- In principle the prime tower should also be on when two model materials are used. However, Method machine do not support this, so this use case does not have to be covered.

PP-401