### PR TITLE
Clean up bot LUT

### DIFF
--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -11,7 +11,7 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
         </name>
         <GUID>2780b345-577b-4a24-a2c5-12e6aad3e690</GUID>
         <version>11</version>
-        <bot_id>abs</bot_id>
+        <bot_material_id>abs</bot_material_id>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>No glue needed</adhesion_info>

--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -11,6 +11,7 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
         </name>
         <GUID>2780b345-577b-4a24-a2c5-12e6aad3e690</GUID>
         <version>11</version>
+        <bot_id>abs</bot_id>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>No glue needed</adhesion_info>

--- a/generic_abs_175.xml.fdm_material
+++ b/generic_abs_175.xml.fdm_material
@@ -11,7 +11,7 @@ Generic ABS 1.75mm profile. The data in this file may not be correct for your sp
         </name>
         <GUID>2780b345-577b-4a24-a2c5-12e6aad3e690</GUID>
         <version>11</version>
-        <bot_material_id>abs</bot_material_id>
+        <reference_material_id>abs</reference_material_id>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>
         <adhesion_info>No glue needed</adhesion_info>

--- a/generic_asa_175.xml.fdm_material
+++ b/generic_asa_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ASA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>416eead4-0d8e-4f0b-8bfc-a91a519befa5</GUID>
-        <bot_id>asa</bot_id>
+        <bot_material_id>asa</bot_material_id>
         <version>5</version>
         <color_code>#ffe92a</color_code>
         <description>ASA combines the qualities of ABS with the added benefit of UV resistance and additional moisture resistance making it ideal for equipment exposed to sunlight and rain over long periods of time – such as products for the agriculture, transportation, and power and utility industries.</description>

--- a/generic_asa_175.xml.fdm_material
+++ b/generic_asa_175.xml.fdm_material
@@ -10,6 +10,7 @@ Generic ASA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>416eead4-0d8e-4f0b-8bfc-a91a519befa5</GUID>
+        <bot_id>asa</bot_id>
         <version>5</version>
         <color_code>#ffe92a</color_code>
         <description>ASA combines the qualities of ABS with the added benefit of UV resistance and additional moisture resistance making it ideal for equipment exposed to sunlight and rain over long periods of time – such as products for the agriculture, transportation, and power and utility industries.</description>

--- a/generic_asa_175.xml.fdm_material
+++ b/generic_asa_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic ASA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>416eead4-0d8e-4f0b-8bfc-a91a519befa5</GUID>
-        <bot_material_id>asa</bot_material_id>
+        <reference_material_id>asa</reference_material_id>
         <version>5</version>
         <color_code>#ffe92a</color_code>
         <description>ASA combines the qualities of ABS with the added benefit of UV resistance and additional moisture resistance making it ideal for equipment exposed to sunlight and rain over long periods of time – such as products for the agriculture, transportation, and power and utility industries.</description>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -10,6 +10,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
             <color>Generic</color>
         </name>
         <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
+        <bot_id>nylon</bot_id>
         <version>7</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
             <color>Generic</color>
         </name>
         <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
-        <bot_id>nylon</bot_id>
+        <bot_material_id>nylon</bot_material_id>
         <version>7</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>

--- a/generic_nylon_175.xml.fdm_material
+++ b/generic_nylon_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon 1.75mm profile. The data in this file may not be correct for your 
             <color>Generic</color>
         </name>
         <GUID>283d439a-3490-4481-920c-c51d8cdecf9c</GUID>
-        <bot_material_id>nylon</bot_material_id>
+        <reference_material_id>nylon</reference_material_id>
         <version>7</version>
         <color_code>#3DF266</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>

--- a/generic_pc_175.xml.fdm_material
+++ b/generic_pc_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC 1.75mm profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>62414577-94d1-490d-b1e4-7ef3ec40db02</GUID>
-        <bot_material_id>pc</bot_material_id>
+        <reference_material_id>pc</reference_material_id>
         <version>6</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>

--- a/generic_pc_175.xml.fdm_material
+++ b/generic_pc_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PC 1.75mm profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>62414577-94d1-490d-b1e4-7ef3ec40db02</GUID>
-        <bot_id>pc</bot_id>
+        <bot_material_id>pc</bot_material_id>
         <version>6</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>

--- a/generic_pc_175.xml.fdm_material
+++ b/generic_pc_175.xml.fdm_material
@@ -10,6 +10,7 @@ Generic PC 1.75mm profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>62414577-94d1-490d-b1e4-7ef3ec40db02</GUID>
+        <bot_id>pc</bot_id>
         <version>6</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
             <color>Generic</color>
         </name>
         <GUID>69386c85-5b6c-421a-bec5-aeb1fb33f060</GUID>
-        <bot_material_id>petg</bot_material_id>
+        <reference_material_id>petg</reference_material_id>
         <version>6</version>
         <color_code>#f3a112</color_code>
         <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
             <color>Generic</color>
         </name>
         <GUID>69386c85-5b6c-421a-bec5-aeb1fb33f060</GUID>
-        <bot_id>petg</bot_id>
+        <bot_material_id>petg</bot_material_id>
         <version>6</version>
         <color_code>#f3a112</color_code>
         <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>

--- a/generic_petg_175.xml.fdm_material
+++ b/generic_petg_175.xml.fdm_material
@@ -10,6 +10,7 @@ Generic PETG 1.75mm profile. The data in this file may not be correct for your s
             <color>Generic</color>
         </name>
         <GUID>69386c85-5b6c-421a-bec5-aeb1fb33f060</GUID>
+        <bot_id>petg</bot_id>
         <version>6</version>
         <color_code>#f3a112</color_code>
         <description>Generic PETG profile. The data in this file may not be correct for your specific machine.</description>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -10,6 +10,7 @@ Generic PLA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>0ff92885-617b-4144-a03c-9989872454bc</GUID>
+        <bot_id>pla</bot_id>
         <version>11</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PLA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>0ff92885-617b-4144-a03c-9989872454bc</GUID>
-        <bot_id>pla</bot_id>
+        <bot_material_id>pla</bot_material_id>
         <version>11</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>

--- a/generic_pla_175.xml.fdm_material
+++ b/generic_pla_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PLA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>0ff92885-617b-4144-a03c-9989872454bc</GUID>
-        <bot_material_id>pla</bot_material_id>
+        <reference_material_id>pla</reference_material_id>
         <version>11</version>
         <color_code>#ffc924</color_code>
         <description>Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.</description>

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>a4255da2-cb2a-4042-be49-4a83957a2f9a</GUID>
-        <bot_material_id>pva</bot_material_id>
+        <reference_material_id>pva</reference_material_id>
         <version>10</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -10,6 +10,7 @@ Generic PVA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>a4255da2-cb2a-4042-be49-4a83957a2f9a</GUID>
+        <bot_id>pva</bot_id>
         <version>10</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>

--- a/generic_pva_175.xml.fdm_material
+++ b/generic_pva_175.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PVA 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>a4255da2-cb2a-4042-be49-4a83957a2f9a</GUID>
-        <bot_id>pva</bot_id>
+        <bot_material_id>pva</bot_material_id>
         <version>10</version>
         <color_code>#a32bcc</color_code>
         <description>Water soluble support material. PVA is a matching support material for PLA, CPE and Nylon.</description>

--- a/scripts/fdmmaterial.xsd
+++ b/scripts/fdmmaterial.xsd
@@ -34,6 +34,14 @@
                                                 </xsd:restriction>
                                             </xsd:simpleType>
                                         </xsd:element>
+                                        <xsd:element name="bot_material_id">
+                                            <xsd:simpleType>
+                                                <xsd:restriction base="xsd:string">
+                                                    <xsd:minLength value="2"/>
+                                                    <xsd:maxLength value="100"/>
+                                                </xsd:restriction>
+                                            </xsd:simpleType>
+                                        </xsd:element>
                                         <xsd:element name="label" type="xsd:string" minOccurs="0"/>
                                     </xsd:all>
                                 </xsd:complexType>

--- a/scripts/fdmmaterial.xsd
+++ b/scripts/fdmmaterial.xsd
@@ -34,14 +34,6 @@
                                                 </xsd:restriction>
                                             </xsd:simpleType>
                                         </xsd:element>
-                                        <xsd:element name="reference_material_id">
-                                            <xsd:simpleType>
-                                                <xsd:restriction base="xsd:string">
-                                                    <xsd:minLength value="2"/>
-                                                    <xsd:maxLength value="100"/>
-                                                </xsd:restriction>
-                                            </xsd:simpleType>
-                                        </xsd:element>
                                         <xsd:element name="label" type="xsd:string" minOccurs="0"/>
                                     </xsd:all>
                                 </xsd:complexType>
@@ -64,6 +56,7 @@
                                 </xsd:simpleType>
                             </xsd:element>
 
+                            <xsd:element name="reference_material_id" type="xsd:string" minOccurs="0"/>
                             <xsd:element name="description" type="xsd:string" minOccurs="0"/>
                             <xsd:element name="adhesion_info" type="xsd:string" minOccurs="0"/>
                             <xsd:element name="instruction_link" type="url" minOccurs="0"/>

--- a/scripts/fdmmaterial.xsd
+++ b/scripts/fdmmaterial.xsd
@@ -34,7 +34,7 @@
                                                 </xsd:restriction>
                                             </xsd:simpleType>
                                         </xsd:element>
-                                        <xsd:element name="bot_material_id">
+                                        <xsd:element name="reference_material_id">
                                             <xsd:simpleType>
                                                 <xsd:restriction base="xsd:string">
                                                     <xsd:minLength value="2"/>

--- a/ultimaker_abscf_175.xml.fdm_material
+++ b/ultimaker_abscf_175.xml.fdm_material
@@ -7,6 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>495a0ce5-9daf-4a16-b7b2-06856d82394d</GUID>
+        <bot_id>abs-cf10</bot_id>
         <version>4</version>
         <color_code>#0e0e10</color_code>
         <description>The performance of carbon fiber with the reliability of ABS</description>

--- a/ultimaker_abscf_175.xml.fdm_material
+++ b/ultimaker_abscf_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>495a0ce5-9daf-4a16-b7b2-06856d82394d</GUID>
-        <bot_id>abs-cf10</bot_id>
+        <bot_material_id>abs-cf10</bot_material_id>
         <version>4</version>
         <color_code>#0e0e10</color_code>
         <description>The performance of carbon fiber with the reliability of ABS</description>

--- a/ultimaker_abscf_175.xml.fdm_material
+++ b/ultimaker_abscf_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>495a0ce5-9daf-4a16-b7b2-06856d82394d</GUID>
-        <bot_material_id>abs-cf10</bot_material_id>
+        <reference_material_id>abs-cf10</reference_material_id>
         <version>4</version>
         <color_code>#0e0e10</color_code>
         <description>The performance of carbon fiber with the reliability of ABS</description>

--- a/ultimaker_absr_175.xml.fdm_material
+++ b/ultimaker_absr_175.xml.fdm_material
@@ -7,6 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>88c8919c-6a09-471a-b7b6-e801263d862d</GUID>
+        <bot_id>abs-wss1</bot_id>
         <version>4</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>

--- a/ultimaker_absr_175.xml.fdm_material
+++ b/ultimaker_absr_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>88c8919c-6a09-471a-b7b6-e801263d862d</GUID>
-        <bot_id>abs-wss1</bot_id>
+        <bot_material_id>abs-wss1</bot_material_id>
         <version>4</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>

--- a/ultimaker_absr_175.xml.fdm_material
+++ b/ultimaker_absr_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>88c8919c-6a09-471a-b7b6-e801263d862d</GUID>
-        <bot_material_id>abs-wss1</bot_material_id>
+        <reference_material_id>abs-wss1</reference_material_id>
         <version>4</version>
         <color_code>#8cb219</color_code>
         <description>Tough and durable. ABS is good for mechanical parts. It is impact resistant, dimensionally stable and handles temperatures up to 85ºC.</description>

--- a/ultimaker_rapidrinse_175.xml.fdm_material
+++ b/ultimaker_rapidrinse_175.xml.fdm_material
@@ -7,7 +7,8 @@
             <color>Generic</color>
         </name>
         <GUID>a140ef8f-4f26-4e73-abe0-cfc29d6d1024</GUID>
-        <version>5</version>
+        <bot_id>wss1</bot_id>
+        <version>4</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material for ABS-R.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -28,7 +29,7 @@
 
         <!-- Define as soluble support material -->
         <cura:setting key="material_is_support_material">True</cura:setting>
-        <cura:setting key="prime_tower_enable">=extruder_nr==support_extruder_nr</cura:setting>
+        <cura:setting key="prime_tower_enable">=extruder_nr==support_extruder_nr and support_enable</cura:setting>
         <cura:setting key="support_conical_enabled">True</cura:setting>
 
         <machine>

--- a/ultimaker_rapidrinse_175.xml.fdm_material
+++ b/ultimaker_rapidrinse_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>a140ef8f-4f26-4e73-abe0-cfc29d6d1024</GUID>
-        <bot_material_id>wss1</bot_material_id>
+        <reference_material_id>wss1</reference_material_id>
         <version>5</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material for ABS-R.</description>

--- a/ultimaker_rapidrinse_175.xml.fdm_material
+++ b/ultimaker_rapidrinse_175.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Generic</color>
         </name>
         <GUID>a140ef8f-4f26-4e73-abe0-cfc29d6d1024</GUID>
-        <bot_id>wss1</bot_id>
+        <bot_material_id>wss1</bot_material_id>
         <version>4</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material for ABS-R.</description>

--- a/ultimaker_rapidrinse_175.xml.fdm_material
+++ b/ultimaker_rapidrinse_175.xml.fdm_material
@@ -8,7 +8,7 @@
         </name>
         <GUID>a140ef8f-4f26-4e73-abe0-cfc29d6d1024</GUID>
         <bot_material_id>wss1</bot_material_id>
-        <version>4</version>
+        <version>5</version>
         <color_code>#f5f2d1</color_code>
         <description>Water soluble support material for ABS-R.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -29,7 +29,7 @@
 
         <!-- Define as soluble support material -->
         <cura:setting key="material_is_support_material">True</cura:setting>
-        <cura:setting key="prime_tower_enable">=extruder_nr==support_extruder_nr and support_enable</cura:setting>
+        <cura:setting key="prime_tower_enable">=extruder_nr==support_extruder_nr</cura:setting>
         <cura:setting key="support_conical_enabled">True</cura:setting>
 
         <machine>


### PR DESCRIPTION
We had a lot of Look up Tables scattered around in the cura repository. This can be solved by adding a `bot_id` entry to metadata of the various makerbot extruders/materials/definitions