### PR TITLE
CURA-10831

### DIFF
--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -31,5 +31,4 @@ jobs:
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
       recipe_id_latest: ${{ needs.conan-recipe-version.outputs.recipe_id_latest }}
-      conan_export_binaries: false
     secrets: inherit

--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -19,16 +19,15 @@ on:
       - '[0-9]+.[0-9]+.[0-9]*'
       - '[0-9]+.[0-9]+.[0-9]'
 
-# FIXME: point to `main` once merged
 jobs:
   conan-recipe-version:
-    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@main
     with:
       project_name: fdm_materials
 
   conan-package-export-linux:
     needs: [ conan-recipe-version ]
-    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-export.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-export.yml@main
     with:
       recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
       recipe_id_latest: ${{ needs.conan-recipe-version.outputs.recipe_id_latest }}

--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - master
+      - 'PP-*'
       - 'CURA-*'
       - '[0-9].[0-9]*'
     tags:

--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
     conan-recipe-version:
-        uses: ultimaker/cura/.github/workflows/conan-recipe-version.yml@main
+        uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
         with:
             project_name: fdm_materials
 

--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -1,57 +1,35 @@
----
 name: conan-package
 
-# Exports the recipe, sources and binaries for Mac, Windows and Linux and upload these to the server such that these can
-# be used downstream.
-#
-# It should run on pushes against main or CURA-* branches, but it will only create the binaries for main and release branches
-
 on:
-    workflow_dispatch:
-    push:
-        paths:
-            - '*.xml.*'
-            - '*.sig'
-            - 'conanfile.py'
-            - '.github/workflows/conan-package.yml'
-            - '.github/workflows/requirements*.txt'
-        branches:
-            - main
-            - master
-            - 'CURA-*'
-            - '[0-9].[0-9]*'
-        tags:
-            - '[1-9]+.[0-9]+.[0-9]*'
-            - '[1-9]+.[0-9]+.[0-9]'
+  workflow_dispatch:
+  push:
+    paths:
+      - '*.xml.*'
+      - '*.sig'
+      - 'conanfile.py'
+      - '.github/workflows/conan-package.yml'
+      - '.github/workflows/requirements*.txt'
+    branches:
+      - main
+      - master
+      - 'CURA-*'
+      - '[0-9].[0-9]*'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]*'
+      - '[0-9]+.[0-9]+.[0-9]'
 
+# FIXME: point to `main` once merged
 jobs:
-    conan-recipe-version:
-        uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
-        with:
-            project_name: fdm_materials
+  conan-recipe-version:
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-version.yml@CURA-10831
+    with:
+      project_name: fdm_materials
 
-    conan-package-export-linux:
-        needs: [ conan-recipe-version ]
-        uses: ultimaker/cura/.github/workflows/conan-recipe-export.yml@main
-        with:
-            recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
-            recipe_id_latest: ${{ needs.conan-recipe-version.outputs.recipe_id_latest }}
-            runs_on: 'ubuntu-20.04'
-            python_version: '3.10.x'
-            conan_config_branch: 'master'
-            conan_logging_level: 'info'
-            conan_export_binaries: true
-        secrets: inherit
-
-    notify-export:
-        if: ${{ always() }}
-        needs: [ conan-recipe-version, conan-package-export-linux ]
-
-        uses: ultimaker/cura/.github/workflows/notify.yml@main
-        with:
-            success: ${{ contains(join(needs.*.result, ','), 'success') }}
-            success_title: "New Conan recipe exported in ${{ github.repository }}"
-            success_body: "Exported ${{ needs.conan-recipe-version.outputs.recipe_id_full }}"
-            failure_title: "Failed to export Conan Export in ${{ github.repository }}"
-            failure_body: "Failed to exported ${{ needs.conan-recipe-version.outputs.recipe_id_full }}"
-        secrets: inherit
+  conan-package-export-linux:
+    needs: [ conan-recipe-version ]
+    uses: ultimaker/cura-workflows/.github/workflows/conan-recipe-export.yml@CURA-10831
+    with:
+      recipe_id_full: ${{ needs.conan-recipe-version.outputs.recipe_id_full }}
+      recipe_id_latest: ${{ needs.conan-recipe-version.outputs.recipe_id_latest }}
+      conan_export_binaries: false
+    secrets: inherit

--- a/.github/workflows/process-pull-request.yml
+++ b/.github/workflows/process-pull-request.yml
@@ -1,15 +1,11 @@
 name: process-pull-request
 
 on:
-    pull_request_target:
-        types: [opened, reopened, edited, synchronize, review_requested, ready_for_review, assigned]
+  pull_request_target:
+    types: [ opened, reopened, edited, review_requested, ready_for_review, assigned ]
 
+# FIXME: Use `main` instead of `CURA-10831` once merged
 jobs:
-    add_label:
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v2
-            -   uses: actions-ecosystem/action-add-labels@v1
-                if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-                with:
-                    labels: 'PR: Community Contribution :crown:'
+  add_label:
+    uses: ultimaker/cura-workflows/.github/workflows/process-pull-request.yml@CURA-10831
+    secrets: inherit

--- a/.github/workflows/process-pull-request.yml
+++ b/.github/workflows/process-pull-request.yml
@@ -4,8 +4,7 @@ on:
   pull_request_target:
     types: [ opened, reopened, edited, review_requested, ready_for_review, assigned ]
 
-# FIXME: Use `main` instead of `CURA-10831` once merged
 jobs:
   add_label:
-    uses: ultimaker/cura-workflows/.github/workflows/process-pull-request.yml@CURA-10831
+    uses: ultimaker/cura-workflows/.github/workflows/process-pull-request.yml@main
     secrets: inherit

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,2 @@
 version: "5.6.0-beta.1"
+release: false

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,2 +1,1 @@
 version: "5.6.0-beta.1"
-release: false

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "5.6.0-beta.1"
+version: "5.7.0-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,1 @@
+version: "5.6.0-beta.1"

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.files import copy
+from conan.tools.files import copy, update_conandata
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
@@ -23,6 +23,9 @@ class FDM_MaterialsConan(ConanFile):
     def set_version(self):
         if not self.version:
             self.version = self.conan_data["version"]
+
+    def export(self):
+        update_conandata(self, {"version": self.version})
 
     def export_sources(self):
         copy(self, "*.fdm_material", self.recipe_folder, self.export_sources_folder)

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,7 @@ class FDM_MaterialsConan(ConanFile):
 
     def set_version(self):
         if not self.version:
-            self.version = "5.6.0-beta.1"
+            self.version = self.conan_data["version"]
 
     def export_sources(self):
         copy(self, "*.fdm_material", self.recipe_folder, self.export_sources_folder)


### PR DESCRIPTION
# Description
Ported a lot of workflow to use the reusable workflows in the new [Cura-workflows](https://github.com/Ultimaker/Cura-workflows) repository. See PR: https://github.com/Ultimaker/cura-workflows/pull/1 

The biggest impact on this repository is that the version of the conan package is now determined by the `version` key in `conandata.yml` and no longer determined based on the git tag. During a push the Conan user, channel is determined based Github runner context, see the `conan-recipe-versions.yml` in the Cura-workflows and the semver build metadata is added from the sha of the reference name (git hash).

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Locally
- [X] Remote

**Test Configuration**:
* Operating System: Linux, Windows, Mac

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
