### PR TITLE
Fix ASA and PA12-CF material profiles

### DIFF
--- a/ultimaker_asa_175.xml.fdm_material
+++ b/ultimaker_asa_175.xml.fdm_material
@@ -8,7 +8,7 @@
         </name>
         <GUID>f79bc612-21eb-482e-ad6c-87d75bdde066</GUID>
         <reference_material_id>asa</reference_material_id>
-        <version>4</version>
+        <version>5</version>
         <color_code>#f1ece1</color_code>
         <description>ASA combines the qualities of ABS with the added benefit of UV resistance and additional moisture resistance making it ideal for equipment exposed to sunlight and rain over long periods of time – such as products for the agriculture, transportation, and power and utility industries.</description>
         <adhesion_info>No glue needed</adhesion_info>
@@ -27,6 +27,62 @@
         <setting key="print cooling">0</setting>
         <setting key="hardware compatible">yes</setting>
 
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Method X"/>
+            <setting key="print temperature">255</setting>
+            <setting key="standby temperature">190</setting>
+            <setting key="build volume temperature">93</setting>
+            <setting key="heated bed temperature">95</setting>
+            <cura:setting key="material_shrinkage_percentage">100.44</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.6</cura:setting>
+
+            <hotend id="1A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1XA">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="2A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="2XA">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1C">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="LABS">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Method XL"/>
+            <setting key="print temperature">255</setting>
+            <setting key="standby temperature">190</setting>
+            <setting key="build volume temperature">85</setting>
+            <setting key="heated bed temperature">95</setting>
+            <cura:setting key="material_shrinkage_percentage">100.44</cura:setting>
+            <cura:setting key="material_shrinkage_percentage_z">100.6</cura:setting>
+
+            <hotend id="1A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1XA">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="2A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="2XA">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1C">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="LABS">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
 
    </settings>
 </fdmmaterial>

--- a/ultimaker_nylon12-cf_175.xml.fdm_material
+++ b/ultimaker_nylon12-cf_175.xml.fdm_material
@@ -8,7 +8,7 @@
         </name>
         <GUID>3c6f2877-71cc-4760-84e6-4b89ab243e3b</GUID>
         <reference_material_id>nylon12-cf</reference_material_id>
-        <version>4</version>
+        <version>5</version>
         <color_code>#0e0e10</color_code>
         <description>Nylon is strong, abrasion-resistant, durable and engineered for low moisture sensitivity.</description>
         <adhesion_info>Use glue.</adhesion_info>
@@ -29,6 +29,49 @@
         <cura:setting key="material_shrinkage_percentage">100.44</cura:setting>
         <cura:setting key="material_shrinkage_percentage_z">100.6</cura:setting>
 
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Method X"/>
+            <setting key="build volume temperature">93</setting>
+            <hotend id="1A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1XA">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="2A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="2XA">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1C">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="LABS">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Method XL"/>
+            <hotend id="1A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1XA">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="2A">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="2XA">
+                <setting key="hardware compatible">no</setting>
+            </hotend>
+            <hotend id="1C">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+            <hotend id="LABS">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
    </settings>
 
 </fdmmaterial>


### PR DESCRIPTION
The Method X and Method XL sections were missing in the profiles leading to wrong settings. 