### PR TITLE
remove cmake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,3 @@
-# For MSVC flags, will be ignored on non-Windows OS's and this project in general. Only needed for cura-build-environment.
-cmake_policy(SET CMP0091 NEW)
-
 project(fdm-materials NONE)
 
 cmake_minimum_required(VERSION 2.8.12)


### PR DESCRIPTION
This is now set in the conan_toolchain.cmake itself and no longer needs to be specified by us generally.

This allows older cmake versions to still create a Debian package