### PR TITLE
Add missing reference_material_id

### DIFF
--- a/generic_bvoh_175.xml.fdm_material
+++ b/generic_bvoh_175.xml.fdm_material
@@ -10,7 +10,8 @@ Generic BVOH 1.75mm profile. The data in this file may not be correct for your s
             <color>Generic</color>
         </name>
         <GUID>923e604c-8432-4b09-96aa-9bbbd42207f4</GUID>
-        <version>2</version>
+        <reference_material_id>bvoh</reference_material_id>
+        <version>3</version>
         <color_code>#ffaaff</color_code>
         <description>This is the baseline profile for the Water soluble support material BVOH. BVOH is a matching support material for PLA, ABS, ASA, PET-G, Nylon, TPU.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>

--- a/generic_cpe_175.xml.fdm_material
+++ b/generic_cpe_175.xml.fdm_material
@@ -10,7 +10,8 @@ Generic CPE 1.75mm profile. The data in this file may not be correct for your sp
             <color>Generic</color>
         </name>
         <GUID>da1872c1-b991-4795-80ad-bdac0f131726</GUID>
-        <version>6</version>
+        <reference_material_id>cpe</reference_material_id>
+        <version>7</version>
         <color_code>#159499</color_code>
         <description>Chemically resistant and tough. CPE is chemically inert, tough, dimensionally stable and handles temperatures up to 70ºC.</description>
         <adhesion_info>Use glue.</adhesion_info>

--- a/generic_hips_175.xml.fdm_material
+++ b/generic_hips_175.xml.fdm_material
@@ -10,7 +10,8 @@ Generic HIPS 1.75mm profile. The data in this file may not be correct for your s
             <color>Generic</color>
         </name>
         <GUID>a468d86a-220c-47eb-99a5-bbb47e514eb0</GUID>
-        <version>5</version>
+        <reference_material_id>hips</reference_material_id>
+        <version>6</version>
         <color_code>#12f3e0</color_code>
         <description>Support material.</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>

--- a/generic_pc_175.xml.fdm_material
+++ b/generic_pc_175.xml.fdm_material
@@ -10,7 +10,8 @@ Generic PC 1.75mm profile. The data in this file may not be correct for your spe
             <color>Generic</color>
         </name>
         <GUID>62414577-94d1-490d-b1e4-7ef3ec40db02</GUID>
-        <version>7</version>
+        <reference_material_id>pc</reference_material_id>
+        <version>8</version>
         <color_code>#F29030</color_code>
         <description>Strong, tough and temperature resistant. PC offers a great print quality, heat resistance up to 110ºC, mechanical strength and toughness.</description>
         <adhesion_info>Use glue for small prints. An adhesion sheet is recommended for larger prints. Set your print speed to a low value (10mm/sec) to get better layer bonding.</adhesion_info>

--- a/generic_tpu_175.xml.fdm_material
+++ b/generic_tpu_175.xml.fdm_material
@@ -10,7 +10,8 @@ Generic TPU 95A 1.75mm profile. The data in this file may not be correct for you
             <color>Generic</color>
         </name>
         <GUID>19baa6a9-94ff-478b-b4a1-8157b74358d2</GUID>
-        <version>12</version>
+        <reference_material_id>tpu</reference_material_id>
+        <version>13</version>
         <color_code>#B22744</color_code>
         <description>Wear and tear resistant. TPU features a Shore-A hardness of 95 and an elongation of up to 580% at break. Suitable for applications that require slight flexibility, wear and tear, and chemical resistance.</description>
         <adhesion_info>Use glue.</adhesion_info>


### PR DESCRIPTION
PR from Jelle Spijker.

Curator gets its reference_material_id from the material definitions without an actual mapping.

See also: https://github.com/Ultimaker/autogenerate_print_profiles/pull/216 from which the materials were generated based on the 5.9 branch

Contribute to NP-474