### PR TITLE
Add metallic PLA material for Sketch printers

### DIFF
--- a/ultimaker_metallic_pla_175.xml.fdm_material
+++ b/ultimaker_metallic_pla_175.xml.fdm_material
@@ -8,9 +8,9 @@
         </name>
         <GUID>3fac1543-dd0c-462d-9cbc-d94137d43999</GUID>
         <reference_material_id>metallic-pla</reference_material_id>
-        <version>1</version>
+        <version>2</version>
         <color_code>#2E5266</color_code>
-        <description>Fast, safe and reliable printing. Silk PLA is ideal for the fast and reliable printing of parts and prototypes with a shiny surface quality.</description>
+        <description>Fast, safe and reliable printing. Metallic PLA is ideal for the fast and reliable printing of parts and prototypes with a shiny surface quality.</description>
         <adhesion_info>Print directly on a clean build surface.</adhesion_info>
     </metadata>
     <properties>

--- a/ultimaker_metallic_pla_175.xml.fdm_material
+++ b/ultimaker_metallic_pla_175.xml.fdm_material
@@ -8,8 +8,8 @@
         </name>
         <GUID>3fac1543-dd0c-462d-9cbc-d94137d43999</GUID>
         <reference_material_id>metallic-pla</reference_material_id>
-        <version>2</version>
-        <color_code>#2E5266</color_code>
+        <version>3</version>
+        <color_code>#80643f</color_code>
         <description>Fast, safe and reliable printing. Metallic PLA is ideal for the fast and reliable printing of parts and prototypes with a shiny surface quality.</description>
         <adhesion_info>Print directly on a clean build surface.</adhesion_info>
     </metadata>

--- a/ultimaker_metallic_pla_175.xml.fdm_material
+++ b/ultimaker_metallic_pla_175.xml.fdm_material
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Ultimaker</brand>
+            <material>Metallic PLA</material>
+            <color>Generic</color>
+        </name>
+        <GUID>3fac1543-dd0c-462d-9cbc-d94137d43999</GUID>
+        <reference_material_id>metallic-pla</reference_material_id>
+        <version>1</version>
+        <color_code>#2E5266</color_code>
+        <description>Fast, safe and reliable printing. Silk PLA is ideal for the fast and reliable printing of parts and prototypes with a shiny surface quality.</description>
+        <adhesion_info>Print directly on a clean build surface.</adhesion_info>
+    </metadata>
+    <properties>
+        <density>1.24</density>
+        <diameter>1.75</diameter>
+        <weight>750</weight>
+    </properties>
+    <settings>
+        <setting key="print temperature">230</setting>
+        <setting key="heated bed temperature">55</setting>
+        <setting key="print cooling">100</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">100</setting>
+
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Sketch" />
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Sketch Large" />
+            <setting key="print temperature">230</setting>
+            <setting key="print cooling">100</setting>
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+        <machine>
+            <machine_identifier manufacturer="Ultimaker B.V." product="UltiMaker Sketch Sprint" />
+            <setting key="print temperature">230</setting>
+            <setting key="standby temperature">180</setting>
+            <setting key="print cooling">100</setting>
+            <setting key="heated bed temperature">55</setting>
+            <cura:setting key="material_bed_temperature_layer_0">60</cura:setting>
+            <cura:setting key="cool_min_temperature">220</cura:setting>
+            <cura:setting key="material_print_temperature_layer_0">235</cura:setting>
+            <hotend id="0.4mm">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
+        </machine>
+
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
Previously we used the PLA profile to print Metallic PLA.
There were drastic differences in surface quality (matte vs shiny).
Also, nozzle failures should be reduced with settings
adjustments made specifically for this material.

New material and quality files were added to address these issues.

PP-552