### PR TITLE
NP-862 replicator support cura cloud

### DIFF
--- a/ultimaker_pla_175.xml.fdm_material
+++ b/ultimaker_pla_175.xml.fdm_material
@@ -145,6 +145,9 @@
             <hotend id="Smart Extruder+">
                 <setting key="hardware compatible">yes</setting>
             </hotend>
+            <hotend id="Smart Extruder+ Experimental">
+                <setting key="hardware compatible">yes</setting>
+            </hotend>
         </machine>
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
Curator has the following assumptions when creating the matcher for  a material.

If in the machine block of an fdm_material there is **ANY** hotend defined then the other hotends for that material are incompatible.  See UltiMaker PLA forn the S-lines they don't define CC and DD cores therefore and Cura marks them as incompatible.

If there are **NO** hotend defined in any hotend for that machine is compatible.

And a dev can set the the hardware compatibility explicit to yes/no

This seemed to work for everything, but apparently Cura still does some other Voodoo Magic.

Adding support in the resources itself is easier than changing the business logic in Curator for this:
- https://github.com/Ultimaker/Curator/blob/c3c0c5a62b4579dd1d69c63d24124a1fa944df5c/include/curator/settings/data/material.h#L250
- https://github.com/Ultimaker/Curator/blob/c3c0c5a62b4579dd1d69c63d24124a1fa944df5c/include/curator/configuration/matching_rules.h#L190


Which has a change to introduce regressions in our existing printer support. This should not change the behaviour of Cura

Contribute to NP-862

FYI @Frederic98, @pkuiper-ultimaker and @alanbjorklund 