### PR TITLE
Improve deprime settings PA-CF slide

### DIFF
--- a/generic_nylon-cf-slide.xml.fdm_material
+++ b/generic_nylon-cf-slide.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <color>Generic</color>
         </name>
         <GUID>000d008b-2f42-4952-ac17-397c354022df</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#1e1e1e</color_code>
         <description>A POM like material with a very good wear resistance and very low friction coefficient.</description>
         <adhesion_info />
@@ -30,7 +30,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
         <setting key="break preparation temperature">280</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">50</setting>
-        <setting key="break temperature">265</setting>
+        <setting key="break temperature">275</setting>
         <setting key="pressure release dwell time">25</setting>
         <setting key="dwell time before break preparation move">0</setting>
         <setting key="end of print purge volume">0</setting>

--- a/ultimaker_nylon-cf-slide.xml.fdm_material
+++ b/ultimaker_nylon-cf-slide.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>b31d12a3-ed0e-4fe4-88f2-5ba6416ae8e5</GUID>
-        <version>4</version>
+        <version>5</version>
         <color_code>#1e1e1e</color_code>
         <description>A POM like material with a very good wear resistance and very low friction coefficient.</description>
         <adhesion_info />
@@ -29,7 +29,7 @@
         <setting key="break preparation temperature">280</setting>
         <setting key="break position">-50</setting>
         <setting key="break speed">50</setting>
-        <setting key="break temperature">265</setting>
+        <setting key="break temperature">275</setting>
         <setting key="pressure release dwell time">25</setting>
         <setting key="dwell time before break preparation move">0</setting>
         <setting key="end of print purge volume">0</setting>


### PR DESCRIPTION
Increase the break temperature of PA-CF slide to prevent anchor forming that can cause unreliable material unloading.

PP-643