### PR TITLE
PP-641 Improve breakaway support

### DIFF
--- a/generic_bam.xml.fdm_material
+++ b/generic_bam.xml.fdm_material
@@ -10,7 +10,7 @@ Generic break away support material profile. The data in this file may not be co
             <color>Generic</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d6a0</GUID>
-        <version>37</version>
+        <version>38</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -91,6 +91,7 @@ Generic break away support material profile. The data in this file may not be co
             <setting key="print cooling">100</setting>
             <setting key="standby temperature">200</setting>
             <setting key="no load move factor">1.0</setting>
+            <cura:setting key="support_structure">tree</cura:setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/generic_nylon-cf-slide.xml.fdm_material
+++ b/generic_nylon-cf-slide.xml.fdm_material
@@ -10,7 +10,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <color>Generic</color>
         </name>
         <GUID>000d008b-2f42-4952-ac17-397c354022df</GUID>
-        <version>6</version>
+        <version>7</version>
         <color_code>#1e1e1e</color_code>
         <description>A POM like material with a very good wear resistance and very low friction coefficient.</description>
         <adhesion_info />
@@ -98,6 +98,7 @@ Generic Nylon profile. The data in this file may not be correct for your specifi
             <setting key="no load move factor">1.0</setting>
             <cura:setting key="material_pressure_advance_factor">0.75</cura:setting>
             <setting key="retraction amount">6.5</setting>
+            <setting key="adhesion tendency">4</setting>
 
             <hotend id="CC+ 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/generic_petcf.xml.fdm_material
+++ b/generic_petcf.xml.fdm_material
@@ -10,7 +10,7 @@ Generic PET-CF profile. The data in this file may not be correct for your specif
             <color>Generic</color>
         </name>
         <GUID>64d44410-be10-428c-8891-f0ae47ea1734</GUID>
-        <version>30</version>
+        <version>31</version>
         <color_code>#888888</color_code>
         <description>Generic PET CF profile. The data in this file may not be correct for your specific machine.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -124,6 +124,7 @@ Generic PET-CF profile. The data in this file may not be correct for your specif
             <setting key="standby temperature">255</setting>
             <setting key="no load move factor">1.0</setting>
             <setting key="print cooling">25</setting>
+            <setting key="adhesion tendency">4</setting>
             <cura:setting key="material_shrinkage_percentage">100.15</cura:setting>
             <setting key="retraction amount">8</setting>
 

--- a/ultimaker_bam.xml.fdm_material
+++ b/ultimaker_bam.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>White</color>
         </name>
         <GUID>7e6207c4-22ff-441a-b261-ff89f166d5f9</GUID>
-        <version>42</version>
+        <version>43</version>
         <color_code>#F1ECE1</color_code>
         <description>Breakaway Material. Breakaway is a matching support material for PLA, ABS, CPE, CPE+, and Nylon</description>
         <adhesion_info>Use the same temperatures and adhesion method as your build material(s).</adhesion_info>
@@ -90,6 +90,7 @@
             <setting key="print cooling">100</setting>
             <setting key="standby temperature">200</setting>
             <setting key="no load move factor">1.0</setting>
+            <cura:setting key="support_structure">tree</cura:setting>
 
             <hotend id="AA 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/ultimaker_nylon-cf-slide.xml.fdm_material
+++ b/ultimaker_nylon-cf-slide.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>b31d12a3-ed0e-4fe4-88f2-5ba6416ae8e5</GUID>
-        <version>6</version>
+        <version>7</version>
         <color_code>#1e1e1e</color_code>
         <description>A POM like material with a very good wear resistance and very low friction coefficient.</description>
         <adhesion_info />
@@ -97,6 +97,7 @@
             <setting key="no load move factor">1.0</setting>
             <cura:setting key="material_pressure_advance_factor">0.75</cura:setting>
             <setting key="retraction amount">6.5</setting>
+            <setting key="adhesion tendency">4</setting>
 
             <hotend id="CC+ 0.4">
                 <setting key="hardware compatible">yes</setting>

--- a/ultimaker_petcf.xml.fdm_material
+++ b/ultimaker_petcf.xml.fdm_material
@@ -8,7 +8,7 @@
             <label>Any color PET-CF</label>
         </name>
         <GUID>f0245d40-3657-4615-b9ab-19fc043944ca</GUID>
-        <version>13</version>
+        <version>14</version>
         <color_code>#888888</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -125,6 +125,7 @@
             <setting key="standby temperature">255</setting>
             <setting key="no load move factor">1.0</setting>
             <setting key="print cooling">25</setting>
+            <setting key="adhesion tendency">4</setting>
             <cura:setting key="material_shrinkage_percentage">100.15</cura:setting>
             <setting key="retraction amount">8</setting>
 

--- a/ultimaker_petcf_black.xml.fdm_material
+++ b/ultimaker_petcf_black.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Black</color>
         </name>
         <GUID>a6f8d4f1-7205-40cc-b9e5-3bad20bc8011</GUID>
-        <version>27</version>
+        <version>28</version>
         <color_code>#1e1e1e</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -123,6 +123,7 @@
             <setting key="standby temperature">255</setting>
             <setting key="no load move factor">1.0</setting>
             <setting key="print cooling">25</setting>
+            <setting key="adhesion tendency">4</setting>
             <cura:setting key="material_shrinkage_percentage">100.15</cura:setting>
             <setting key="retraction amount">8</setting>
 

--- a/ultimaker_petcf_blue.xml.fdm_material
+++ b/ultimaker_petcf_blue.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Blue</color>
         </name>
         <GUID>81555f45-354b-42e0-bc0d-e0357cb56dd4</GUID>
-        <version>27</version>
+        <version>28</version>
         <color_code>#025669</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -123,6 +123,7 @@
             <setting key="standby temperature">255</setting>
             <setting key="no load move factor">1.0</setting>
             <setting key="print cooling">25</setting>
+            <setting key="adhesion tendency">4</setting>
             <cura:setting key="material_shrinkage_percentage">100.15</cura:setting>
             <setting key="retraction amount">8</setting>
 

--- a/ultimaker_petcf_gray.xml.fdm_material
+++ b/ultimaker_petcf_gray.xml.fdm_material
@@ -7,7 +7,7 @@
             <color>Gray</color>
         </name>
         <GUID>98896281-3972-4dc5-8d6d-76ed417b10ea</GUID>
-        <version>27</version>
+        <version>28</version>
         <color_code>#8d948d</color_code>
         <description>Ultimaker PET-CF.</description>
         <adhesion_info>Print on bare glass.</adhesion_info>
@@ -123,6 +123,7 @@
             <setting key="standby temperature">255</setting>
             <setting key="no load move factor">1.0</setting>
             <setting key="print cooling">25</setting>
+            <setting key="adhesion tendency">4</setting>
             <cura:setting key="material_shrinkage_percentage">100.15</cura:setting>
             <setting key="retraction amount">8</setting>
 


### PR DESCRIPTION
Add CC+0.6 core for S8:

- Increased z distance between BAM and PETCF/PACF
- Set default support structure for BAM to tree 