### PR TITLE
PP-704 Add ASA Generic for Factor Line

### DIFF
--- a/generic_asa.xml.fdm_material
+++ b/generic_asa.xml.fdm_material
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Generic ASA profile. The data in this file may not be correct for your specific machine.
+-->
+<fdmmaterial xmlns="http://www.ultimaker.com/material" xmlns:cura="http://www.ultimaker.com/cura" version="1.3">
+    <metadata>
+        <name>
+            <brand>Generic</brand>
+            <material>ASA</material>
+            <color>Generic</color>
+        </name>
+        <GUID>50361850-7d30-404d-943e-a3166dc11be2</GUID>
+        <version>1</version>
+        <color_code>#FAF4DC</color_code>
+        <description>ASA combines the qualities of ABS with the added benefit of UV resistance and additional moisture resistance making it ideal for equipment exposed to sunlight and rain over long periods of time – such as products for the agriculture, transportation, and power and utility industries.</description>
+        <adhesion_info>No glue needed</adhesion_info>
+        <cura:pva_compatible>False</cura:pva_compatible>
+        <cura:breakaway_compatible>True</cura:breakaway_compatible>
+    </metadata>
+    <properties>
+        <density>1.06</density>
+        <diameter>2.85</diameter>
+    </properties>
+    <settings>
+        <!-- Deprime settings -->
+        <setting key="anti ooze retract position">-4</setting>
+        <setting key="anti ooze retract speed">3</setting>
+        <setting key="break preparation position">-16</setting>
+        <setting key="break preparation speed">50</setting>
+        <setting key="break preparation temperature">240</setting>
+        <setting key="break position">-50</setting>
+        <setting key="break speed">25</setting>
+        <setting key="break temperature">100</setting>
+        <setting key="pressure release dwell time">25</setting>
+        <setting key="dwell time before break preparation move">4</setting>
+        <setting key="end of print purge volume">0</setting>
+        <setting key="end of filament purge volume">0</setting>
+        <setting key="flush purge length">60</setting>
+
+        <!-- material station (un)loading settings -->
+        <setting key="maximum park duration">7200</setting>
+        <setting key="no load move factor">0.92</setting>
+
+        <!-- print settings -->
+        <setting key="print temperature">255</setting>
+        <setting key="standby temperature">145</setting>
+        <setting key="heated bed temperature">95</setting>
+        <setting key="build volume temperature">50</setting>
+        <setting key="adhesion tendency">0</setting>
+        <setting key="surface energy">70</setting>
+        <cura:setting key="cool_fan_speed_max">15</cura:setting>
+        <cura:setting key="material_shrinkage_percentage">100</cura:setting>
+
+        <!-- For material flow sensor -->
+        <setting key="relative extrusion">1.0</setting>
+        <setting key="retract compensation">0</setting>
+
+    <machine>
+      <machine_identifier manufacturer="Ultimaker B.V." product="Ultimaker Factor 4" />
+      <setting key="anti ooze retract position">-2</setting>
+      <setting key="break preparation position">-10</setting>
+      <setting key="build volume temperature">50</setting>
+      <setting key="heated bed temperature">95</setting>
+      <setting key="no load move factor">1</setting>
+      <setting key="print cooling">20</setting>
+      <setting key="print temperature">255</setting>
+      <cura:setting key="cool_fan_speed_max">100</cura:setting>
+      <cura:setting key="material_shrinkage_percentage">100.3</cura:setting>
+      <hotend id="AA 0.4">
+        <setting key="hardware compatible">yes</setting>
+        <setting key="print temperature">255</setting>
+      </hotend>
+    </machine>
+
+    </settings>
+</fdmmaterial>


### PR DESCRIPTION
# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This adds a Generic ASA profile for Factor 4 printers, to assist users in setting up the print process for this material.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Quality and Intent profile

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Deployed in Cura 5.12 master builds
- [x] Printed multiple prints on Factor 4 with different ASA grades, including testing of deprimes

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
