### PR TITLE
Swap spool weights for two materials

### DIFF
--- a/ultimaker_nylon-cf-slide.xml.fdm_material
+++ b/ultimaker_nylon-cf-slide.xml.fdm_material
@@ -18,7 +18,7 @@
     <properties>
         <density>1.04</density>
         <diameter>2.85</diameter>
-        <weight>500</weight>
+        <weight>750</weight>
     </properties>
     <settings>
         <!-- Deprime settings -->

--- a/ultimaker_ppscf_metallic-anthracite.xml.fdm_material
+++ b/ultimaker_ppscf_metallic-anthracite.xml.fdm_material
@@ -18,7 +18,7 @@
     <properties>
         <density>1.51</density>
         <diameter>2.85</diameter>
-        <weight>750</weight>
+        <weight>500</weight>
     </properties>
     <settings>
         <setting key="anti ooze retract position">-8</setting>


### PR DESCRIPTION
Correct spool weight values in two material definitions: ultimaker_nylon-cf-slide.xml.fdm_material (weight changed from 500 to 750) and ultimaker_ppscf_metallic-anthracite.xml.fdm_material (weight changed from 750 to 500). This fixes filament mass metadata used for material handling and remaining filament calculations.

https://ultimaker.com/materials/factor-series-pps-carbon-fiber/

https://ultimaker.com/materials/nylon-cf-slide/

CURA-13009