### PR TITLE
Add FilAr filament materials (PLA, PLA Mate, PETG)

### DIFF
--- a/FilAr_PETG_Black.xml.fdm_material
+++ b/FilAr_PETG_Black.xml.fdm_material
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>FilAr</brand>
+            <material>PETG</material>
+            <color>Black</color>
+        <label>PETG Black</label>
+        </name>
+        <color_code>#000000</color_code>
+        <GUID>fccab426-dc18-4a92-9f06-b75d4e43e317</GUID>
+        <adhesion_info />
+        <version>1</version>
+        <description />
+    </metadata>
+    <properties>
+        <diameter>1.75</diameter>
+        <density>1.27</density>
+        <weight>1000</weight>
+    </properties>
+    <settings>
+        <setting key="standby temperature">205.0</setting>
+        <setting key="print cooling">40.0</setting>
+        <setting key="retraction amount">3</setting>
+        <setting key="print temperature">240.0</setting>
+        <setting key="heated bed temperature">78.0</setting>
+        <setting key="retraction speed">20.0</setting>
+    </settings>
+</fdmmaterial>

--- a/FilAr_PLA_Black.xml.fdm_material
+++ b/FilAr_PLA_Black.xml.fdm_material
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>FilAr</brand>
+            <material>PLA</material>
+            <color>Black</color>
+        <label>PLA Black</label>
+        </name>
+        <color_code>#000000</color_code>
+        <GUID>22511811-9c3e-41c0-9281-0327a8970d81</GUID>
+        <adhesion_info />
+        <version>1</version>
+        <description />
+    </metadata>
+    <properties>
+        <diameter>1.75</diameter>
+        <density>1.24</density>
+        <weight>1000</weight>
+    </properties>
+    <settings>
+        <setting key="standby temperature">195.0</setting>
+        <setting key="print cooling">100.0</setting>
+        <setting key="retraction amount">3</setting>
+        <setting key="print temperature">210.0</setting>
+        <setting key="heated bed temperature">60.0</setting>
+        <setting key="retraction speed">40.0</setting>
+    </settings>
+</fdmmaterial>

--- a/FilAr_PLA_Mate_Black.xml.fdm_material
+++ b/FilAr_PLA_Mate_Black.xml.fdm_material
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fdmmaterial version="1.3" xmlns="http://www.ultimaker.com/material">
+    <metadata>
+        <name>
+            <brand>FilAr</brand>
+            <material>PLA</material>
+            <color>Black</color>
+        <label>PLA Mate Black</label>
+        </name>
+        <color_code>#1A1A1A</color_code>
+        <GUID>8b73443a-2c1e-419f-844e-034c4d003a49</GUID>
+        <adhesion_info />
+        <version>1</version>
+        <description />
+    </metadata>
+    <properties>
+        <diameter>1.75</diameter>
+        <density>1.24</density>
+        <weight>1000</weight>
+    </properties>
+    <settings>
+        <setting key="standby temperature">185.0</setting>
+        <setting key="print cooling">100.0</setting>
+        <setting key="retraction amount">3</setting>
+        <setting key="print temperature">200.0</setting>
+        <setting key="heated bed temperature">60.0</setting>
+        <setting key="retraction speed">40.0</setting>
+    </settings>
+</fdmmaterial>

--- a/FilAr_PLA_Mate_Black.xml.fdm_material
+++ b/FilAr_PLA_Mate_Black.xml.fdm_material
@@ -23,7 +23,7 @@
         <setting key="print cooling">100.0</setting>
         <setting key="retraction amount">3</setting>
         <setting key="print temperature">200.0</setting>
-        <setting key="heated bed temperature">60.0</setting>
+        <setting key="heated bed temperature">50.0</setting>
         <setting key="retraction speed">40.0</setting>
     </settings>
 </fdmmaterial>


### PR DESCRIPTION
Adds **FilAr**, an Argentine filament manufacturer (https://www.filar.com.ar), to the material database with three materials: **PLA**, **PLA Mate** and **PETG**.

Each file follows the existing third-party brand convention (e.g. eSUN, 3D-Fuel): a single `.xml.fdm_material` per material with its own fresh UUIDv4 `GUID`, `version` 1, no `<machine>` blocks.

| File | Material | Print temp | Bed | Density |
|---|---|---|---|---|
| `FilAr_PLA_Black` | PLA | 210 °C | 60 °C | 1.24 |
| `FilAr_PLA_Mate_Black` | PLA (matte) | 200 °C | 60 °C | 1.24 |
| `FilAr_PETG_Black` | PETG | 240 °C | 78 °C | 1.27 |

Diameter 1.75 mm. Values follow the manufacturer's published datasheet. Black is provided as the representative color; additional colors can be added as a follow-up if desired.

These profiles are already part of OrcaSlicer's filament library (OrcaSlicer/OrcaSlicer#13977, merged). Contribution is released under the repository's CC0-1.0 license.
